### PR TITLE
fix: 카테고리 등 탭 페이지 404 오류 수정

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,11 @@ theme_mode: light
 toc: true
 paginate: 10
 
+collections:
+  tabs:
+    output: true
+    sort_by: order
+
 defaults:
   - scope:
       path: ""


### PR DESCRIPTION
## Summary
- `_config.yml`에 `collections: tabs:` 선언 추가
- 누락된 컬렉션 선언으로 인해 Jekyll이 `_tabs/` 디렉토리를 처리하지 못해 `/categories/`, `/tags/`, `/archives/`, `/about/` 페이지가 빌드되지 않던 문제 해결

## Test plan
- [x] `bundle exec jekyll build` 성공
- [x] `_site/categories/index.html` 생성 확인
- [x] `_site/tags/index.html` 생성 확인
- [x] `_site/archives/index.html` 생성 확인
- [x] `_site/about/index.html` 생성 확인

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)