### PR TITLE
docs: PyPI 배포 아키텍처 포스팅 보완 — wheel/sdist 개념 + Git 직접 실행 기각

### DIFF
--- a/_posts/2026-02-19-uvx-python-version-trap.md
+++ b/_posts/2026-02-19-uvx-python-version-trap.md
@@ -137,6 +137,9 @@ if [[ -n "$PYTHON_CMD" ]]; then
      { [[ "$PYTHON_MAJOR" -eq 3 ]] && [[ "$PYTHON_MINOR" -lt 10 ]]; }; then
     PYTHON_TOO_OLD=true
   fi
+else
+  # Python 미설치 — uvx가 자동으로 3.10 다운로드
+  PYTHON_TOO_OLD=true
 fi
 
 # MCP 서버 등록 시 조건 분기
@@ -167,7 +170,7 @@ uvx에서만 무시될 뿐입니다.
 |-----------|-----------|
 | requires-python이 모든 곳에서 작동한다 | uvx와 uv tool에서는 무시된다 (의도된 설계) |
 | uvx와 uv run이 같은 방식으로 Python을 고른다 | 완전히 다른 탐색 로직을 쓴다 |
-| pyproject.toml에 버전 명시하면 충분하다 | setup.sh에서 Python 버전 체크 후 `--python` 플래그를 자동 부여해야 한다 |
+| pyproject.toml에 버전 명시하면 충분하다 | setup.sh에서 버전 체크 후 `--python`을 자동 부여해야 한다 |
 | `--python` 지정하면 시스템에 해당 버전이 있어야 하나 | uv가 자동으로 다운로드하여 실행한다 |
 
 ---


### PR DESCRIPTION
## Summary
- 배포 편: wheel vs sdist 역할, PyPI 저장소 역할, Git 직접 실행 대안 기각, auto-tag.yml 태그 자동화, 몰랐던 것 테이블, 바이브 코딩 인사이트 추가
- Python 버전 편: 해결 방안 톤 "제안"→"적용 완료" 변경, #109 실제 구현 코드 반영, `--python 3.10` 실측 결과, 몰랐던 것 테이블 확장

## Test plan
- [x] 배포 편 — wheel vs sdist 테이블 렌더링 확인
- [x] 배포 편 — "왜 PyPI인가 — 대안 검토" 섹션 흐름 확인
- [x] 배포 편 — auto-tag.yml 코드블록 + PAT_TOKEN 설명 확인
- [x] 배포 편 — 몰랐던 것 테이블 4항목 확인
- [x] 배포 편 — 마무리 바이브 코딩 인사이트 확인
- [x] Python 버전 편 — 섹션 5 제목/톤 "적용 완료" 확인
- [x] Python 버전 편 — setup.sh 실제 구현 코드 발췌 확인
- [x] Python 버전 편 — 몰랐던 것 테이블 4행 확인

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)