### PR TITLE
docs: 개발 사전·실무 노하우 블로그 퍼블리시 (#77)

### DIFF
--- a/_posts/2026-03-08-configuration-cascade.md
+++ b/_posts/2026-03-08-configuration-cascade.md
@@ -1,0 +1,71 @@
+---
+title: "Configuration Cascade — 로컬이 글로벌을 이기는 설정 전략"
+date: 2026-03-08 00:00:00 +0900
+categories: [기술 노하우, 개발 사전]
+tags: [개발사전, 설계, 아키텍처]
+description: >-
+  여러 계층의 설정이 존재할 때,
+  가장 가까운 설정이 먼 설정을 덮어쓰는
+  Configuration Cascade 패턴을 정리합니다.
+---
+
+## TL;DR
+
+여러 계층의 설정이 존재할 때,
+**가장 가까운(구체적인) 설정이 먼(일반적인) 설정을 덮어쓰는** 패턴입니다.
+CSS specificity, Git config, Spring property override 모두 같은 원리입니다.
+
+## 핵심 원리
+
+- **계층 우선순위**: 로컬 > 프로젝트 > 글로벌 > 기본값 순으로 적용됩니다
+- **부분 덮어쓰기**: 하위 계층은 상위 계층 전체를 대체하지 않고,
+  지정된 키만 덮어씁니다
+- **폴백(Fallback)**: 하위 계층에 값이 없으면
+  상위 계층 값을 그대로 사용합니다
+
+## 실무 적용
+
+CLI 도구의 환경변수 설정에 적용했습니다.
+
+| 계층 | 경로 | 용도 |
+|------|------|------|
+| 로컬 | `.env` (프로젝트 루트) | 프로젝트 전용 설정 |
+| 글로벌 | `~/.config/.env` | 개인 기본 설정 |
+
+로딩 로직은 로컬 파일이 있으면 로컬을 사용하고,
+없으면 글로벌로 폴백합니다.
+
+```bash
+ENV_FILE=$( [ -f .env ] && echo ".env" || echo "$HOME/.config/.env" )
+```
+
+### Spring Boot 설정 캐스케이드
+
+Spring Boot도 같은 원리로 동작합니다.
+같은 키를 여러 소스에서 선언하면, 가까운 쪽이 이깁니다.
+
+| 우선순위 | 소스 | 예시 |
+|---------|------|------|
+| 1 (최고) | 커맨드라인 인자 | `--server.port=9090` |
+| 2 | 환경변수 | `SERVER_PORT=9090` |
+| 3 | profile YAML | `application-dev.yml` |
+| 4 (최저) | 기본 YAML | `application.yml` |
+
+```yaml
+# application.yml — 기본값
+server:
+  port: 8080
+  servlet:
+    context-path: /api
+
+# application-dev.yml — port만 덮어씁니다
+server:
+  port: 8081
+```
+
+`dev` 프로필로 실행하면 port는 8081이 되고,
+context-path는 기본값 `/api`를 그대로 씁니다.
+port는 부분 덮어쓰기, context-path는 폴백 —
+캐스케이드의 두 축이 동시에 작동합니다.
+
+*이 글은 Claude의 도움을 받아 작성했습니다.*

--- a/_posts/2026-03-08-jpa-idclass-data-annotation-tradeoff.md
+++ b/_posts/2026-03-08-jpa-idclass-data-annotation-tradeoff.md
@@ -1,0 +1,102 @@
+---
+title: "@Data vs 개별 어노테이션 — JPA 복합 키 클래스의 트레이드오프"
+date: 2026-03-08 00:00:00 +0900
+categories: [기술 노하우, 실무 노하우]
+tags: [설계, 아키텍처, 개발사전]
+description: >-
+  JPA @IdClass 복합 키 클래스에서 @Data의 편의성과 @Setter 제거 사이의
+  트레이드오프를 정리합니다.
+  adapter 인프라 클래스에 한해 @Data 수용이 합리적인 이유를 설명합니다.
+---
+
+## TL;DR
+
+JPA @IdClass 복합 키 클래스에서 @Data의 편의성을 수용할 것인가,
+@Setter 제거를 위해 어노테이션을 개별 선언할 것인가의 트레이드오프입니다.
+adapter 인프라 클래스에 한해 @Data 수용은 합리적 판단입니다.
+**단, @Data는 @NoArgsConstructor를 포함하지 않으므로 반드시 명시해야 합니다.**
+
+## 핵심 원리
+
+### Lombok @Data가 생성하는 것
+
+@Getter + @Setter + @EqualsAndHashCode + @ToString + @RequiredArgsConstructor
+
+**주의: @RequiredArgsConstructor ≠ @NoArgsConstructor**
+
+- @RequiredArgsConstructor는 final/@NonNull 필드 대상 생성자를 생성합니다.
+- final 필드가 없으면 매개변수 없는 생성자가 만들어지지만,
+  이것은 **@NoArgsConstructor와 동일하지 않습니다.**
+- Hibernate는 @IdClass/@Embeddable 클래스에 명시적 no-arg constructor를 요구합니다.
+- **@Data + @AllArgsConstructor만으로는 Hibernate가 인스턴스를 생성하지 못해
+  런타임 에러가 발생합니다.**
+
+> 실제 장애 사례: `Unable to locate constructor for embeddable 'CompositeKey'`
+> @Data + @AllArgsConstructor만 선언하고 @NoArgsConstructor를 누락하여 배치 잡이 실패.
+
+### @IdClass vs @EmbeddedId 선택 기준
+
+| 항목 | @IdClass | @EmbeddedId |
+|------|-----------|---------------|
+| @GeneratedValue | **지원** (필드가 엔티티에 직접 선언) | JPA 스펙 미보장 (@Embeddable 내 비표준) |
+| 필드 접근 | entity.getId() (flat) | entity.getId().getId() (중첩) |
+| Record 사용 | 불가 | Hibernate 6+ 지원 |
+
+**결정적 기준**: PK에 @GeneratedValue가 있으면 @IdClass가 유일한 선택지입니다.
+
+### @IdClass에서 Record를 쓸 수 없는 이유
+
+JPA 스펙은 @IdClass에 no-arg constructor를 요구합니다.
+Hibernate 구현체는 no-arg constructor로 인스턴스 생성 후
+리플렉션으로 필드를 세팅하는 순서로 동작합니다.
+
+Java 리플렉션 자체는 Record의 final 필드도 setAccessible(true)로 강제 세팅 가능하지만,
+Hibernate가 @IdClass에 대해 이 방식을 지원하지 않습니다.
+**기술적 제약이 아니라 구현체의 선택입니다.**
+
+## 실무 적용
+
+### 어노테이션 비교
+
+| 방식 | 어노테이션 수 | Setter |
+|------|-------------|--------|
+| @Data + @NoArgsConstructor + @AllArgsConstructor | 3개 | 있음 |
+| 개별 선언 (@Getter + @EqualsAndHashCode + @ToString + @NoArgsConstructor + @AllArgsConstructor) | 5개 | 없음 |
+
+### 판단 기준
+
+- no setter 원칙의 본래 목적은 **도메인 불변식 보호**입니다.
+- @IdClass 키 클래스는 adapter 계층의 인프라 코드이며, 비즈니스 불변식이 없습니다.
+- setter 호출처가 존재하지 않으므로 실질적 위험이 없습니다.
+- 미끄러운 경사면(adapter에서 domain으로 확산) 위험은
+  헥사고날 아키텍처 경계로 통제됩니다.
+
+**결론**: adapter 인프라 클래스에 한해 @Data 편의성 수용은 합리적 트레이드오프입니다.
+
+## 코드 예시
+
+```java
+// @IdClass 키 클래스 - @Data 사용
+// ⚠️ @NoArgsConstructor 필수 — @Data는 이를 포함하지 않음
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemKey implements Serializable {
+  private Long id;
+  private LocalDate orderDate;
+}
+
+// 엔티티 - @GeneratedValue 때문에 @IdClass 필수
+@IdClass(OrderItemKey.class)
+@Entity
+public class OrderItemEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  private Long id;
+
+  @Id
+  private LocalDate orderDate;
+}
+```
+
+*이 글은 Claude의 도움을 받아 작성했습니다.*


### PR DESCRIPTION
## Summary

- 위키 포스팅 2편을 블로그로 퍼블리시
  - @Data vs 개별 어노테이션 — JPA 복합 키 클래스의 트레이드오프 (실무 노하우)
  - Configuration Cascade — 로컬이 글로벌을 이기는 설정 전략 (개발 사전)
- 대외비 제거: `SourceInstanceKey` → `CompositeKey`, "소스 수집 잡" → "배치 잡"
- Configuration Cascade 말투 합쇼체 통일

Closes #77

## Test plan

- [x] 대외비 패턴 검사 (사내 URL, 프로젝트 고유명, 인명, 토큰)
- [x] front matter 형식 확인 (title, date, categories, tags, description)
- [x] 말투 통일 확인 (합쇼체)
- [x] 마지막 줄 Claude 크레딧 확인
- [x] 위키 원본 Configuration Cascade 합쇼체 변환 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)