### PR TITLE
fix: TL;DR 강조 영역 누락 수정 (#79)

### DIFF
--- a/_posts/2026-03-08-configuration-cascade.md
+++ b/_posts/2026-03-08-configuration-cascade.md
@@ -9,11 +9,10 @@ description: >-
   Configuration Cascade 패턴을 정리합니다.
 ---
 
-## TL;DR
-
-여러 계층의 설정이 존재할 때,
-**가장 가까운(구체적인) 설정이 먼(일반적인) 설정을 덮어쓰는** 패턴입니다.
-CSS specificity, Git config, Spring property override 모두 같은 원리입니다.
+> **TL;DR** 여러 계층의 설정이 존재할 때,
+> **가장 가까운(구체적인) 설정이 먼(일반적인) 설정을 덮어쓰는** 패턴입니다.
+> CSS specificity, Git config, Spring property override 모두 같은 원리입니다.
+{: .prompt-tip }
 
 ## 핵심 원리
 

--- a/_posts/2026-03-08-jpa-idclass-data-annotation-tradeoff.md
+++ b/_posts/2026-03-08-jpa-idclass-data-annotation-tradeoff.md
@@ -9,12 +9,11 @@ description: >-
   adapter 인프라 클래스에 한해 @Data 수용이 합리적인 이유를 설명합니다.
 ---
 
-## TL;DR
-
-JPA @IdClass 복합 키 클래스에서 @Data의 편의성을 수용할 것인가,
-@Setter 제거를 위해 어노테이션을 개별 선언할 것인가의 트레이드오프입니다.
-adapter 인프라 클래스에 한해 @Data 수용은 합리적 판단입니다.
-**단, @Data는 @NoArgsConstructor를 포함하지 않으므로 반드시 명시해야 합니다.**
+> **TL;DR** JPA @IdClass 복합 키 클래스에서 @Data의 편의성을 수용할 것인가,
+> @Setter 제거를 위해 어노테이션을 개별 선언할 것인가의 트레이드오프입니다.
+> adapter 인프라 클래스에 한해 @Data 수용은 합리적 판단입니다.
+> **단, @Data는 @NoArgsConstructor를 포함하지 않으므로 반드시 명시해야 합니다.**
+{: .prompt-tip }
 
 ## 핵심 원리
 


### PR DESCRIPTION
## Summary

- 2편의 TL;DR에 `.prompt-tip` 강조 영역 추가
- 기존 포스트 패턴과 일관성 확보

Closes #79

## Test plan

- [x] blockquote + `{: .prompt-tip }` 형식 확인
- [x] 기존 포스트 TL;DR 패턴과 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)