### PR TITLE
chore: JSON-LD publisher 생성을 위한 logo 필드 추가

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ github:
   username: idean3885
 
 author: idean3885
+logo: /assets/img/favicons/favicon-96x96.png
 
 social:
   name: idean3885


### PR DESCRIPTION
## Summary
- `_config.yml`에 `logo` 필드 추가 (`favicon-96x96.png`)
- jekyll-seo-tag가 JSON-LD에 `publisher` (Organization + logo) 포함하도록 설정
- #96 에서 author 추가 후 publisher 누락이 확인되어 후속 처리

Closes #93

## Test plan
- [x] `_config.yml` YAML 파싱 정상 확인
- [ ] 배포 후 JSON-LD에 publisher 필드 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)