### PR TITLE
fix: robots.txt Sitemap 경로를 실제 사이트맵 파일로 수정

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -3,4 +3,4 @@ layout: null
 ---
 User-agent: *
 Allow: /
-Sitemap: https://idean3885.github.io
+Sitemap: https://idean3885.github.io/sitemap-manual.xml

--- a/robots.txt
+++ b/robots.txt
@@ -3,4 +3,4 @@ layout: null
 ---
 User-agent: *
 Allow: /
-Sitemap: https://idean3885.github.io
+Sitemap: https://idean3885.github.io/sitemap-manual.xml


### PR DESCRIPTION
## Summary
- `robots.txt`의 `Sitemap` 디렉티브가 홈페이지 URL(`https://idean3885.github.io`)을 가리키고 있어 Google이 XML 대신 HTML을 받아 "가져올 수 없음" 발생
- `sitemap-manual.xml` 경로로 수정하여 Google Search Console 정상 인식 유도

## Test plan
- [x] 로컬 빌드 성공
- [x] `_site/robots.txt`에 `Sitemap: https://idean3885.github.io/sitemap-manual.xml` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)