### PR TITLE
fix: 사이트맵 XML 헤더 단순화로 Google 파싱 실패 방지

### DIFF
--- a/sitemap-manual.xml
+++ b/sitemap-manual.xml
@@ -2,7 +2,7 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://idean3885.github.io/posts/ai-changed-my-workflow/</loc>
         <lastmod>2026-03-16T00:22:46+09:00</lastmod>


### PR DESCRIPTION
## Summary
- `sitemap-manual.xml`의 복잡한 XML namespace 선언(`xsi:schemaLocation`, `xmlns:xsi`) 제거
- Google Search Console이 `*.github.io` 도메인 사이트맵 파싱 시 실패하는 알려진 이슈 대응
- ref: https://github.com/cotes2020/jekyll-theme-chirpy/issues/2658

## Test plan
- [x] 로컬 빌드 성공
- [x] 빌드된 XML 헤더: `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` 확인
- [x] `xmllint --noout` 유효성 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)