### PR TITLE
feat: 탑바 스티키 고정 + 브레드크럼 카테고리 경로 유지

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,0 +1,106 @@
+<!-- The Top Bar -->
+
+<style>
+  #topbar-wrapper { position: sticky; top: 0; z-index: 1020; }
+</style>
+<header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Bar">
+  <div
+    id="topbar"
+    class="d-flex align-items-center justify-content-between px-lg-3 h-100"
+  >
+    <nav id="breadcrumb" aria-label="Breadcrumb">
+      {% assign paths = page.url | split: '/' %}
+
+      {% if paths.size == 0 or page.layout == 'home' %}
+        <!-- index page -->
+        <span>{{ site.data.locales[include.lang].tabs.home | capitalize }}</span>
+
+      {% elsif page.layout == 'post' and page.categories.size > 0 %}
+        <!-- post page: Home > Category > Series > Title -->
+        <span>
+          <a href="{{ '/' | relative_url }}">
+            {{- site.data.locales[include.lang].tabs.home | capitalize -}}
+          </a>
+        </span>
+
+        {% assign cat = page.categories[0] %}
+        <span>
+          <a href="{{ cat | slugify | prepend: '/categories/' | append: '/' | relative_url }}">
+            {{- cat -}}
+          </a>
+        </span>
+
+        {% if page.categories.size > 1 %}
+          {% assign series = page.categories[1] %}
+          <span>
+            <a href="{{ series | slugify | prepend: '/categories/' | append: '/' | relative_url }}">
+              {{- series -}}
+            </a>
+          </span>
+        {% endif %}
+
+        <span>{{ page.title }}</span>
+
+      {% else %}
+        {% for item in paths %}
+          {% if forloop.first %}
+            <span>
+              <a href="{{ '/' | relative_url }}">
+                {{- site.data.locales[include.lang].tabs.home | capitalize -}}
+              </a>
+            </span>
+
+          {% elsif forloop.last %}
+            {% if page.collection == 'tabs' %}
+              <span>{{ site.data.locales[include.lang].tabs[item] | default: page.title }}</span>
+            {% else %}
+              <span>{{ page.title }}</span>
+            {% endif %}
+
+          {% elsif page.layout == 'category' or page.layout == 'tag' %}
+            <span>
+              <a href="{{ item | append: '/' | relative_url }}">
+                {{- site.data.locales[include.lang].tabs[item] | default: page.title -}}
+              </a>
+            </span>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+    </nav>
+    <!-- endof #breadcrumb -->
+
+    <button type="button" id="sidebar-trigger" class="btn btn-link" aria-label="Sidebar">
+      <i class="fas fa-bars fa-fw"></i>
+    </button>
+
+    <div id="topbar-title">
+      {% if page.layout == 'home' %}
+        {{- site.data.locales[include.lang].title | default: site.title -}}
+      {% elsif page.collection == 'tabs' or page.layout == 'page' %}
+        {%- capture tab_key -%}{{ page.url | split: '/' }}{%- endcapture -%}
+        {{- site.data.locales[include.lang].tabs[tab_key] | default: page.title -}}
+      {% else %}
+        {{- site.data.locales[include.lang].layout[page.layout] | default: page.layout | capitalize -}}
+      {% endif %}
+    </div>
+
+    <button type="button" id="search-trigger" class="btn btn-link" aria-label="Search">
+      <i class="fas fa-search fa-fw"></i>
+    </button>
+
+    <search id="search" class="align-items-center ms-3 ms-lg-0">
+      <i class="fas fa-search fa-fw"></i>
+      <input
+        class="form-control"
+        id="search-input"
+        type="search"
+        aria-label="search"
+        autocomplete="off"
+        placeholder="{{ site.data.locales[include.lang].search.hint | capitalize }}..."
+      >
+    </search>
+    <button type="button" class="btn btn-link text-decoration-none" id="search-cancel">
+      {{- site.data.locales[include.lang].search.cancel -}}
+    </button>
+  </div>
+</header>


### PR DESCRIPTION
## 작업 내용
탑바를 스티키로 고정하고, 포스트 페이지 브레드크럼에 카테고리/시리즈 경로를 표시

## 변경 사항
- `_includes/topbar.html` 오버라이드
  - 포스트 페이지: `page.categories` 기반으로 `Home > 카테고리 > 시리즈 > 제목` 생성
  - `#topbar-wrapper`에 `position: sticky; top: 0; z-index: 1020` 적용

## Before / After
- Before: `Home › AI에게 코드를 맡기고 나서 달라진 일하는 방식`
- After: `Home › 개발 기록 › AI 적응기 › AI에게 코드를 맡기고 나서 달라진 일하는 방식`

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `bundle exec jekyll build` |
| 브레드크럼 (2단계 카테고리) | ✅ 확인 | Home > 개발 기록 > AI 적응기 > 제목 |
| 스티키 CSS | ✅ 반영 | `position: sticky` in built HTML |

Closes #154