### PR TITLE
fix: 탑바 스티키 배경색 투명 수정

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,7 +1,12 @@
 <!-- The Top Bar -->
 
 <style>
-  #topbar-wrapper { position: sticky; top: 0; z-index: 1020; }
+  #topbar-wrapper {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+    background-color: var(--topbar-bg, var(--body-bg, #fff));
+  }
 </style>
 <header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Bar">
   <div


### PR DESCRIPTION
## 작업 내용
스크롤 시 콘텐츠가 탑바 뒤로 비쳐 보이는 문제 수정

## 변경 사항
- `#topbar-wrapper` background-color에 fallback 체인 적용: `var(--topbar-bg, var(--body-bg, #fff))`

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `bundle exec jekyll build` |