### PR TITLE
fix: 탑바 스티키 하단 그림자 추가

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -6,6 +6,7 @@
     top: 0;
     z-index: 1020;
     background-color: var(--topbar-bg, var(--body-bg, #fff));
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   }
 </style>
 <header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Bar">


### PR DESCRIPTION
## 작업 내용
스크롤 시 콘텐츠와 탑바 경계가 불분명한 문제 수정

## 변경 사항
- `#topbar-wrapper`에 `box-shadow: 0 1px 3px rgba(0,0,0,0.08)` 추가
- 스크롤 시 탑바와 콘텐츠의 시각적 경계 확보

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | |