### PR TITLE
fix: 탑바 좌우 여백 제거

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -7,6 +7,10 @@
     z-index: 1020;
     background-color: var(--topbar-bg, var(--body-bg, #fff));
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    margin-left: calc(-1 * var(--bs-gutter-x, 0.75rem));
+    margin-right: calc(-1 * var(--bs-gutter-x, 0.75rem));
+    padding-left: var(--bs-gutter-x, 0.75rem);
+    padding-right: var(--bs-gutter-x, 0.75rem);
   }
 </style>
 <header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Bar">


### PR DESCRIPTION
## 작업 내용
탑바가 컨테이너 너비에 갇혀 좌우 여백이 보이는 문제 수정

## 변경 사항
- 음수 마진으로 gutter 상쇄, 패딩으로 내부 정렬 유지
- 탑바 + 그림자가 전체 너비로 표시

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | |