### PR TITLE
fix: 탑바 전체 너비 — 컨테이너 패딩 상쇄 방식

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,16 +1,28 @@
 <!-- The Top Bar -->
 
 <style>
+  /* sticky topbar: 부모 .container 패딩을 상쇄하여 #main-wrapper 전체 너비 사용 */
+  #main-wrapper > .container {
+    position: relative;
+  }
   #topbar-wrapper {
     position: sticky;
     top: 0;
     z-index: 1020;
     background-color: var(--topbar-bg, var(--body-bg, #fff));
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-    width: 100vw;
-    margin-left: calc(-50vw + 50%);
-    padding-left: calc(50vw - 50%);
-    padding-right: calc(50vw - 50%);
+    margin-left: calc(-1 * var(--bs-gutter-x, 12px));
+    margin-right: calc(-1 * var(--bs-gutter-x, 12px));
+    padding-left: var(--bs-gutter-x, 12px);
+    padding-right: var(--bs-gutter-x, 12px);
+  }
+  @media (min-width: 1400px) {
+    #topbar-wrapper {
+      margin-left: -3rem;
+      margin-right: -3rem;
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
   }
 </style>
 <header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Bar">


### PR DESCRIPTION
## 작업 내용
이전 100vw 방식이 사이드바와 충돌하여, 컨테이너 패딩 상쇄 방식으로 전환

## 변경 사항
- `.container` gutter 패딩을 음수 마진으로 상쇄
- xxl 브레이크포인트(1400px+)에서 `px-xxl-5`(3rem) 별도 처리
- 사이드바 영역은 침범하지 않음

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | |