### PR TITLE
fix: 사이드바 아바타 중앙 정렬, 사이즈 확대 및 파스텔톤 적용

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -1,0 +1,93 @@
+---
+---
+
+/* prettier-ignore */
+@use 'main
+{%- if jekyll.environment == 'production' -%}
+  .bundle
+{%- endif -%}
+';
+
+/* === Sidebar Profile Customization === */
+
+/* Pastel tone sidebar */
+:root {
+  --sidebar-bg: linear-gradient(180deg, #eef6f3 0%, #f0f0f8 50%, #f6f3f0 100%);
+}
+
+#sidebar {
+  background: linear-gradient(180deg, #eef6f3 0%, #f0f0f8 50%, #f6f3f0 100%);
+
+  /* Avatar: center align & size up */
+  .profile-wrapper {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+    text-align: center;
+  }
+
+  #avatar {
+    display: block;
+    width: 8rem;
+    height: 8rem;
+    margin: 0 auto;
+
+    @media (min-width: 576px) {
+      width: 8.5rem;
+      height: 8.5rem;
+    }
+
+    img {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .site-title {
+    width: 100%;
+    text-align: center;
+  }
+
+  .site-subtitle {
+    text-align: center;
+  }
+}
+
+/* === Right Panel: card style === */
+
+#panel-wrapper .access > section {
+  background: #f8f9fa;
+  border: 1px solid #eef0f2;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 4%);
+}
+
+#panel-wrapper .post-tag {
+  background: #f0f4f8;
+  border: 1px solid #e2e8f0;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #e8eef6;
+    border-color: #cbd5e1;
+  }
+}
+
+/* TOC: card style + topbar clearance */
+#toc-wrapper {
+  top: 4rem;
+  background: #f8f9fa;
+  border: 1px solid #eef0f2;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 4%);
+
+  &::before,
+  &::after {
+    display: none;
+  }
+}
+
+.toc-border-cover {
+  display: none;
+}


### PR DESCRIPTION
## 작업 내용

사이드바 프로필 영역 및 우측 패널 디자인 개선

## 변경 사항

- 아바타 이미지 중앙 정렬 및 사이즈 8rem/8.5rem으로 확대
- 사이드바 배경에 파스텔 그라데이션(민트→라벤더→피치) 적용
- 우측 패널 섹션(Recently Updated, Trending Tags) 카드 스타일 적용
- TOC(Contents) 카드 스타일 적용 및 흰색 그라데이션 오버레이 제거

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `bundle exec jekyll serve` |
| 테스트 | ⬜ 해당없음 | CSS 변경만 포함 |
| 문서 동기화 | ⬜ 해당없음 | |

Closes #161