### PR TITLE
feat: Giscus 댓글 시스템 연동

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,18 @@ avatar: /assets/img/avatar.PNG
 
 social_preview_image: /assets/img/og-image.png
 
+comments:
+  provider: giscus
+  giscus:
+    repo: idean3885/idean3885.github.io
+    repo_id: R_kgDORQ49gw
+    category: General
+    category_id: DIC_kwDORQ49g84C59HT
+    mapping: pathname
+    lang: ko
+    input_position: bottom
+    reactions_enabled: 1
+
 theme_mode: light
 
 toc: true
@@ -46,7 +58,7 @@ defaults:
       type: posts
     values:
       layout: post
-      comments: false
+      comments: true
       toc: true
       permalink: /posts/:title/
   - scope:


### PR DESCRIPTION
## Summary
- GitHub Discussions 기반 Giscus 댓글 위젯을 블로그에 추가
- Chirpy 테마 기본 지원 활용 — `_config.yml` 설정만 변경
- 모든 포스트에 댓글 기능 활성화 (`comments: true`)

Closes #165

## Test plan
- [x] `bundle exec jekyll build` 성공
- [x] 빌드된 HTML에 Giscus 스크립트 삽입 확인
- [ ] 배포 후 포스트 하단 댓글 위젯 렌더링 확인
- [ ] GitHub 로그인 후 댓글 작성/조회 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)