### PR TITLE
chore: 커스텀 도메인 blog.idean.me 연결 (#169)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Jekyll + Chirpy 테마 기반 블로그 프로젝트
 
 | 항목 | 내용 |
 |------|------|
-| 사이트 | https://idean3885.github.io |
+| 사이트 | https://blog.idean.me |
 | 테마 | [jekyll-theme-chirpy](https://github.com/cotes2020/jekyll-theme-chirpy) |
 | 언어 | 한국어 (ko) |
 | 배포 | GitHub Pages (GitHub Actions) |

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+blog.idean.me

--- a/_config.yml
+++ b/_config.yml
@@ -9,13 +9,15 @@ description: >-
   개발자로서의 기술적 탐구, 방법론의 진화,
   운영 노하우와 의사결정의 기록을 담는 블로그.
 
-url: "https://idean3885.github.io"
+url: "https://blog.idean.me"
 baseurl: ""
 
 github:
   username: idean3885
 
-author: idean3885
+author:
+  name: idean3885
+  url: https://github.com/idean3885
 logo: /assets/img/favicons/favicon-96x96.png
 
 social:

--- a/llms.txt
+++ b/llms.txt
@@ -12,27 +12,27 @@
 ## 주요 시리즈
 
 ### AI 적응기
-- [AI에게 코드를 맡기고 나서 달라진 일하는 방식](https://idean3885.github.io/posts/ai-changed-my-workflow/)
-- [코딩에서 사고로 — AI 시대 개발자의 역할 전환](https://idean3885.github.io/posts/from-coding-to-thinking/)
-- [방법론을 들고 첫 도구를 만들었다 — Slack to Notion 제작기](https://idean3885.github.io/posts/building-first-tool-with-ai/)
-- [만든 도구를 검증하다 — 테스트가 설계를 바꾼 이야기](https://idean3885.github.io/posts/testing-changed-architecture/)
-- [비개발자 관점으로 써봤더니 설치부터 막혔다](https://idean3885.github.io/posts/e2e-lessons-from-non-developers/)
-- [건네도 될까에서 건넸다로 — 비개발자 실전 피드백](https://idean3885.github.io/posts/real-feedback-from-non-developer/)
-- [.mcpb 원클릭 설치 — Desktop Extension까지](https://idean3885.github.io/posts/mcpb-one-click-install/)
+- [AI에게 코드를 맡기고 나서 달라진 일하는 방식](https://blog.idean.me/posts/ai-changed-my-workflow/)
+- [코딩에서 사고로 — AI 시대 개발자의 역할 전환](https://blog.idean.me/posts/from-coding-to-thinking/)
+- [방법론을 들고 첫 도구를 만들었다 — Slack to Notion 제작기](https://blog.idean.me/posts/building-first-tool-with-ai/)
+- [만든 도구를 검증하다 — 테스트가 설계를 바꾼 이야기](https://blog.idean.me/posts/testing-changed-architecture/)
+- [비개발자 관점으로 써봤더니 설치부터 막혔다](https://blog.idean.me/posts/e2e-lessons-from-non-developers/)
+- [건네도 될까에서 건넸다로 — 비개발자 실전 피드백](https://blog.idean.me/posts/real-feedback-from-non-developer/)
+- [.mcpb 원클릭 설치 — Desktop Extension까지](https://blog.idean.me/posts/mcpb-one-click-install/)
 
 ### 기술 노하우
-- [uvx requires-python의 함정](https://idean3885.github.io/posts/uvx-python-version-trap/)
-- [Java 개발자를 위한 uvx 가이드](https://idean3885.github.io/posts/uvx-guide-for-java-developers/)
-- [uvx + PyPI 배포 자동화](https://idean3885.github.io/posts/uvx-pypi-deploy-automation/)
-- [Chirpy 블로그의 SEO는 이미 되어 있었다](https://idean3885.github.io/posts/chirpy-seo-and-search-console/)
-- [설정 캐스케이드 — 계층형 설정 병합 패턴](https://idean3885.github.io/posts/configuration-cascade/)
-- [JPA IdClass와 @Data 어노테이션 트레이드오프](https://idean3885.github.io/posts/jpa-idclass-data-annotation-tradeoff/)
-- [GEO 대응 — 개발 블로그가 AI에게 읽히려면](https://idean3885.github.io/posts/geo-for-dev-blog/)
+- [uvx requires-python의 함정](https://blog.idean.me/posts/uvx-python-version-trap/)
+- [Java 개발자를 위한 uvx 가이드](https://blog.idean.me/posts/uvx-guide-for-java-developers/)
+- [uvx + PyPI 배포 자동화](https://blog.idean.me/posts/uvx-pypi-deploy-automation/)
+- [Chirpy 블로그의 SEO는 이미 되어 있었다](https://blog.idean.me/posts/chirpy-seo-and-search-console/)
+- [설정 캐스케이드 — 계층형 설정 병합 패턴](https://blog.idean.me/posts/configuration-cascade/)
+- [JPA IdClass와 @Data 어노테이션 트레이드오프](https://blog.idean.me/posts/jpa-idclass-data-annotation-tradeoff/)
+- [GEO 대응 — 개발 블로그가 AI에게 읽히려면](https://blog.idean.me/posts/geo-for-dev-blog/)
 
 ### 생각과 방법론
-- [작은 조각들 브레인스토밍](https://idean3885.github.io/posts/small-peaces-brainstorming/)
+- [작은 조각들 브레인스토밍](https://blog.idean.me/posts/small-peaces-brainstorming/)
 
 ### 시스템 구축기
-- [시계열 수집 시스템 쓰기 경합 해결](https://idean3885.github.io/posts/timeseries-write-contention/)
-- [시계열 집계 배치의 점진적 진화](https://idean3885.github.io/posts/timeseries-aggregation-batch-evolution/)
-- [사용자 도메인 인증서 자동 발급 — certbot 학습에서 ACME4j 구현까지](https://idean3885.github.io/posts/domain-ssl-automation-certbot-to-acme4j/)
+- [시계열 수집 시스템 쓰기 경합 해결](https://blog.idean.me/posts/timeseries-write-contention/)
+- [시계열 집계 배치의 점진적 진화](https://blog.idean.me/posts/timeseries-aggregation-batch-evolution/)
+- [사용자 도메인 인증서 자동 발급 — certbot 학습에서 ACME4j 구현까지](https://blog.idean.me/posts/domain-ssl-automation-certbot-to-acme4j/)


### PR DESCRIPTION
## 작업 내용
*.github.io 도메인의 GSC 사이트맵 인식 불가(2개월 지속) 해소를 위해
Cloudflare 도메인(idean.me) 구매 후 blog.idean.me를 GitHub Pages에 연결한다.

## 변경 사항
- CNAME 파일 추가 (`blog.idean.me`)
- `_config.yml` url 변경 (`idean3885.github.io` → `blog.idean.me`)
- `_config.yml` author.url 추가 (JSON-LD author.url 누락 해소, #104-1)
- `llms.txt`, `CLAUDE.md` URL 일괄 변경

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 설정/링크 변경만, 로컬 빌드 불필요 |
| 테스트 | ⬜ 해당없음 | |
| DNS 연결 | ✅ 확인 | `blog.idean.me` → `idean3885.github.io` CNAME 정상 |
| HTTPS | ✅ 확인 | GitHub Pages Enforce HTTPS 활성화 |
| 기존 URL 리다이렉트 | ✅ 확인 | `idean3885.github.io` → `blog.idean.me` 자동 리다이렉트 |

Closes #169