### PR TITLE
fix: 탑바 오버플로 수정, 읽기 진행 스크롤바 추가, Pretendard 폰트 적용 (#171)

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,28 +1,55 @@
 <!-- The Top Bar -->
 
 <style>
-  /* sticky topbar: 부모 .container 패딩을 상쇄하여 #main-wrapper 전체 너비 사용 */
-  #main-wrapper > .container {
-    position: relative;
-  }
+  /* sticky topbar: fixed 방식으로 전체 너비 사용 */
   #topbar-wrapper {
-    position: sticky;
+    position: fixed;
     top: 0;
+    left: 0;
+    right: 0;
     z-index: 1020;
     background-color: var(--topbar-bg, var(--body-bg, #fff));
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-    margin-left: calc(-1 * var(--bs-gutter-x, 12px));
-    margin-right: calc(-1 * var(--bs-gutter-x, 12px));
-    padding-left: var(--bs-gutter-x, 12px);
-    padding-right: var(--bs-gutter-x, 12px);
   }
-  @media (min-width: 1400px) {
+  /* 사이드바 표시 시 (>= 850px) 사이드바 너비만큼 왼쪽 오프셋 */
+  @media (min-width: 850px) {
     #topbar-wrapper {
-      margin-left: -3rem;
-      margin-right: -3rem;
-      padding-left: 3rem;
-      padding-right: 3rem;
+      left: 260px;
     }
+  }
+  @media (min-width: 1650px) {
+    #topbar-wrapper {
+      left: 300px;
+    }
+  }
+  /* topbar 높이만큼 본문 여백 확보 */
+  #main-wrapper > .container {
+    padding-top: 3.5rem;
+  }
+  /* 읽기 진행 스크롤바: topbar 바로 아래 */
+  #reading-progress-wrap {
+    position: fixed;
+    top: 3rem;
+    left: 0;
+    right: 0;
+    z-index: 1019;
+    height: 3px;
+  }
+  @media (min-width: 850px) {
+    #reading-progress-wrap {
+      left: 260px;
+    }
+  }
+  @media (min-width: 1650px) {
+    #reading-progress-wrap {
+      left: 300px;
+    }
+  }
+  #reading-progress {
+    height: 100%;
+    background: #333;
+    width: 0%;
+    transition: width 50ms linear;
   }
 </style>
 <header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Bar">
@@ -126,3 +153,18 @@
     </button>
   </div>
 </header>
+<div id="reading-progress-wrap">
+  <div id="reading-progress"></div>
+</div>
+
+<script>
+  (function () {
+    var bar = document.getElementById('reading-progress');
+    if (!bar) return;
+    window.addEventListener('scroll', function () {
+      var scrollTop = window.scrollY;
+      var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      bar.style.width = docHeight > 0 ? (scrollTop / docHeight * 100) + '%' : '0%';
+    }, { passive: true });
+  })();
+</script>

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -8,6 +8,55 @@
 {%- endif -%}
 ';
 
+/* === Font: Pretendard === */
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
+
+:root {
+  --bs-body-font-family: 'Pretendard Variable', Pretendard, system-ui, -apple-system, sans-serif;
+  --bs-body-font-weight: 400;
+}
+
+/* 모든 요소에 Pretendard 통일 (Lato, Source Sans Pro 등 테마 기본 폰트 오버라이드) */
+body,
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6,
+#sidebar,
+#topbar-wrapper,
+.post-desc,
+.post-content,
+.card-title,
+.card-text,
+.site-title,
+.site-subtitle {
+  font-family: 'Pretendard Variable', Pretendard, system-ui, -apple-system, sans-serif !important;
+}
+
+body {
+  font-weight: 400;
+}
+
+strong, b {
+  font-weight: 600;
+}
+
+h1, h2, h3, h4, h5 {
+  font-weight: 700;
+}
+
+/* === Heading & Description Color === */
+h1, h2, h3, h4, h5 {
+  color: #141414;
+}
+
+.post-desc {
+  color: #777 !important;
+  font-weight: 400 !important;
+}
+
+.post-content p {
+  color: #777;
+}
+
 /* === Sidebar Profile Customization === */
 
 /* Pastel tone sidebar */


### PR DESCRIPTION
## 작업 내용
탑바 레이아웃 수정, 읽기 진행 UI 추가, 폰트 시스템 전면 교체

## 변경 사항
- 탑바를 `fixed` 포지션으로 전환 — 사이드바 너비(260px/300px)에 맞게 `left` 자동 조정
- 읽기 진행 프로그레스 바 추가 (탑바 하단, 검정)
- Pretendard Variable 폰트 전역 적용 (Lato, Source Sans Pro 등 테마 기본 폰트 대체)
- 폰트 웨이트 정리: Regular(400), SemiBold(600), Bold(700) — Light(300) 제거
- 헤딩 색상 `#141414`, 본문/설명 색상 `#777`

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | 로컬 Jekyll serve |
| 탑바 오버플로 | ✅ 해소 | 좁은 화면에서 확인 |
| 프로그레스 바 | ✅ 동작 | 포스트 페이지 스크롤 확인 |
| Pretendard 적용 | ✅ 확인 | description, 본문, 헤딩 전체 |

Closes #171