### PR TITLE
feat: 사이트 전체 포스트 개수 노출 (#218)

### DIFF
--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -1,0 +1,162 @@
+---
+layout: page
+# All the Categories of posts
+---
+
+{% include lang.html %}
+
+{% assign HEAD_PREFIX = 'h_' %}
+{% assign LIST_PREFIX = 'l_' %}
+
+{% assign group_index = 0 %}
+
+{% assign sort_categories = site.categories | sort %}
+
+<!-- Summary: total top-level categories and posts -->
+{% assign top_categories_arr = '' | split: '' %}
+{% for post in site.posts %}
+  {% assign top_cat = post.categories[0] %}
+  {% if top_cat %}
+    {% unless top_categories_arr contains top_cat %}
+      {% assign top_categories_arr = top_categories_arr | push: top_cat %}
+    {% endunless %}
+  {% endif %}
+{% endfor %}
+{% assign top_count = top_categories_arr | size %}
+
+<div class="card mb-3">
+  <div class="card-header d-flex justify-content-between hide-border-bottom">
+    <span class="ms-2">
+      <i class="fas fa-chart-pie fa-fw"></i>
+      <span class="mx-2">전체</span>
+      <span class="text-muted small font-weight-light">
+        {{ top_count }}개 카테고리, {{ site.posts | size }}편
+      </span>
+    </span>
+  </div>
+</div>
+
+{% for category in sort_categories %}
+  {% assign category_name = category | first %}
+  {% assign posts_of_category = category | last %}
+  {% assign first_post = posts_of_category | first %}
+
+  {% if category_name == first_post.categories[0] %}
+    {% assign sub_categories = '' | split: '' %}
+
+    {% for post in posts_of_category %}
+      {% assign second_category = post.categories[1] %}
+      {% if second_category %}
+        {% unless sub_categories contains second_category %}
+          {% assign sub_categories = sub_categories | push: second_category %}
+        {% endunless %}
+      {% endif %}
+    {% endfor %}
+
+    {% assign sub_categories = sub_categories | sort %}
+    {% assign sub_categories_size = sub_categories | size %}
+
+    <div class="card categories">
+      <!-- top-category -->
+      <div
+        id="{{ HEAD_PREFIX }}{{ group_index }}"
+        class="card-header d-flex justify-content-between hide-border-bottom"
+      >
+        <span class="ms-2">
+          <i class="far fa-folder{% if sub_categories_size > 0 %}-open{% endif %} fa-fw"></i>
+
+          {% capture _category_url %}/categories/{{ category_name | slugify | url_encode }}/{% endcapture %}
+          <a href="{{ _category_url | relative_url }}" class="mx-2">{{ category_name }}</a>
+
+          <!-- content count -->
+          {% assign top_posts_size = site.categories[category_name] | size %}
+          <span class="text-muted small font-weight-light">
+            {% if sub_categories_size > 0 %}
+              {{ sub_categories_size }}
+              {% if sub_categories_size > 1 %}
+                {{
+                  site.data.locales[lang].categories.category_measure.plural
+                  | default: site.data.locales[lang].categories.category_measure
+                }}
+              {% else %}
+                {{
+                  site.data.locales[lang].categories.category_measure.singular
+                  | default: site.data.locales[lang].categories.category_measure
+                }}
+              {% endif -%}
+              ,
+            {% endif %}
+
+            {{ top_posts_size }}
+
+            {% if top_posts_size > 1 %}
+              {{
+                site.data.locales[lang].categories.post_measure.plural
+                | default: site.data.locales[lang].categories.post_measure
+              }}
+            {% else %}
+              {{
+                site.data.locales[lang].categories.post_measure.singular
+                | default: site.data.locales[lang].categories.post_measure
+              }}
+            {% endif %}
+          </span>
+        </span>
+
+        <!-- arrow -->
+        {% if sub_categories_size > 0 %}
+          <a
+            href="#{{ LIST_PREFIX }}{{ group_index }}"
+            data-bs-toggle="collapse"
+            aria-expanded="true"
+            aria-label="{{ HEAD_PREFIX }}{{ group_index }}-trigger"
+            class="category-trigger hide-border-bottom"
+          >
+            <i class="fas fa-fw fa-angle-down"></i>
+          </a>
+        {% else %}
+          <span data-bs-toggle="collapse" class="category-trigger hide-border-bottom disabled">
+            <i class="fas fa-fw fa-angle-right"></i>
+          </span>
+        {% endif %}
+      </div>
+      <!-- .card-header -->
+
+      <!-- Sub-categories -->
+      {% if sub_categories_size > 0 %}
+        <div id="{{ LIST_PREFIX }}{{ group_index }}" class="collapse show" aria-expanded="true">
+          <ul class="list-group">
+            {% for sub_category in sub_categories %}
+              <li class="list-group-item">
+                <i class="far fa-folder fa-fw"></i>
+
+                {% capture _sub_ctg_url %}/categories/{{ sub_category | slugify | url_encode }}/{% endcapture %}
+                <a href="{{ _sub_ctg_url | relative_url }}" class="mx-2">{{ sub_category }}</a>
+
+                {% assign posts_size = site.categories[sub_category] | size %}
+                <span class="text-muted small font-weight-light">
+                  {{ posts_size }}
+
+                  {% if posts_size > 1 %}
+                    {{
+                      site.data.locales[lang].categories.post_measure.plural
+                      | default: site.data.locales[lang].categories.post_measure
+                    }}
+                  {% else %}
+                    {{
+                      site.data.locales[lang].categories.post_measure.singular
+                      | default: site.data.locales[lang].categories.post_measure
+                    }}
+                  {% endif %}
+                </span>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    </div>
+    <!-- .card -->
+
+    {% assign group_index = group_index | plus: 1 %}
+  {% endif %}
+{% endfor %}

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -17,6 +17,10 @@ layout: default
   {% assign posts = posts | push: post %}
 {% endfor %}
 
+<p class="post-list-summary text-muted mb-4 ps-md-2">
+  총 <strong>{{ site.posts | size }}</strong>편
+</p>
+
 <div id="post-list" class="flex-grow-1 px-xl-1">
   {% for post in posts %}
     <article class="card-wrapper card">


### PR DESCRIPTION
## 작업 내용

홈/포스트/카테고리 어디에도 사이트 전체 포스트 개수가 노출되지 않던 문제를 해결한다.
포트폴리오/규모 신호로서 자연스러운 위치에 카운트를 노출한다.

## 변경 사항

- `/posts/` 상단에 "총 N편" 텍스트 헤더 추가 (`_layouts/posts.html`)
- `/categories/` 상단에 "N개 카테고리, M편" 요약 카드 추가
- Chirpy의 `_layouts/categories.html`을 로컬 오버라이드로 도입 (이후 카테고리 영역 커스터마이징 기반)

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `bundle exec jekyll build` |
| 렌더링 | ✅ 통과 | `_site/posts/index.html` → "총 35편", `_site/categories/index.html` → "3개 카테고리, 35편" |
| 반응형 | ✅ 통과 | `ps-md-2` 모바일 패딩 제거, `card`/`text-muted` 등 Chirpy 기존 토큰 사용 |
| 테스트 | ⬜ 해당없음 | UI 변경, 자동화 테스트 부재 |
| 문서 동기화 | ⬜ 해당없음 | 문서 변경 없음 |

Closes #218
