### PR TITLE
feat: 홈 페이지 정리 (최신 포스트 자동화 + 시리즈 선별) (#222)

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,53 +15,57 @@ Kubernetes 기반 멀티 테넌시 서비스를 개발하고 운영하며,
 - **생각과 방법론**: 설계 원칙, 의사결정, 개발에 대한 생각
 - **기술 노하우**: 운영 경험에서 얻은 실전 지식
 
+## 최신 포스트
+
+{% for post in site.posts limit:5 %}
+1. [{{ post.title }}]({{ post.url | relative_url }}) <span class="text-muted small">({{ post.date | date: "%Y-%m-%d" }})</span>
+{%- endfor %}
+
+[전체 포스트 보기 →](/posts/)
+
 ## 주요 시리즈
 
-### AI 적응기
-
-AI 기반 개발을 시작하면서 겪은 변화와 깨달음을 시간순으로 정리한 시리즈입니다.
-
-1. [AI에게 코드를 맡기고 나서 달라진 일하는 방식](/posts/ai-changed-my-workflow/)
-2. [코드에서 사고로 - AI 시대, 개발자의 역할 재정의](/posts/from-coding-to-thinking/)
-3. [두 플러그인을 하나로 - devex 사상의 실무 적용](/posts/merging-two-plugins/)
-4. [사내 업무 자동화 체계 구축 - devex에서 toolkit까지](/posts/building-automation-toolkit/)
-
-### Slack to Notion 제작기
-
-Slack 대화를 Notion에 자동 정리하는 도구를 만들고 검증한 과정입니다.
-
-1. [방법론을 들고 첫 도구를 만들었다](/posts/building-first-tool-with-ai/)
-2. [만든 도구를 검증하다 - 테스트가 설계를 바꾼 이야기](/posts/testing-changed-architecture/)
-3. [비개발자 관점으로 써봤더니 설치부터 막혔다](/posts/e2e-lessons-from-non-developers/)
-4. [건네도 될까에서 건넸다로 - 비개발자 실전 피드백](/posts/real-feedback-from-non-developer/)
-5. [남은 한 걸음 - .mcpb로 원클릭 설치까지](/posts/mcpb-one-click-install/)
-
-### AI 교차 검증
-
-AI 협업에서 판단을 검증하는 방법과 도구 구현을 다루는 시리즈입니다.
-
-1. [AI 협업에서의 교차 검증 - 속도가 아닌 판단을 자동화하기](/posts/cross-verification-in-ai-collaboration/)
-2. [교차 검증 도구의 구현 - 자체 검증에서 실전까지](/posts/cross-verify-implementation/)
-3. [교차 검증의 맹점 - OWASP에서 배운 보안 설계 관점](/posts/cross-verify-owasp-security-design/)
+PAAR(Problem → Analyze → Action → Result) 구조의 분석 깊이를 기준으로 선별합니다.
 
 ### 미터링 시스템 구축
 
 GPU 클라우드 서비스의 사용량 수집·집계 시스템을 설계하고 구현한 과정입니다.
 
-1. [시계열 수집의 쓰기 경합 - 5분 주기 시스템에서 동시성을 해결한 방법](/posts/timeseries-write-contention/)
-2. [시계열 집계 배치의 점진적 진화 - 내장 스케줄러에서 서버리스 배치까지](/posts/timeseries-aggregation-batch-evolution/)
-3. [미터링 배치를 만들고 나서야 알게 된 것들 - 배치 전략과 패턴에 이름 붙이기](/posts/batch-patterns-naming/)
+{% assign series = site.posts | where: "categories", "미터링 시스템 구축" | sort: "date" -%}
+{% for post in series %}
+1. [{{ post.title }}]({{ post.url | relative_url }})
+{%- endfor %}
+
+### AI 교차 검증
+
+AI 협업에서 판단을 검증하는 방법과 도구 구현을 다루는 시리즈입니다.
+
+{% assign series = site.posts | where: "categories", "AI 교차 검증" | sort: "date" -%}
+{% for post in series %}
+1. [{{ post.title }}]({{ post.url | relative_url }})
+{%- endfor %}
 
 ### 인증서 자동화 구축기
 
 사용자 도메인 인증서 발급·갱신을 완전 자동화한 과정입니다.
 
-1. [사용자 도메인 인증서 자동 발급 - certbot 학습에서 ACME4j 구현까지](/posts/domain-ssl-automation-certbot-to-acme4j/)
-2. [와일드카드 인증서 갱신 완전 자동화 - Docker IPC에서 Jenkins 배치까지](/posts/wildcard-cert-automation-docker-ipc-jenkins/)
+{% assign series = site.posts | where: "categories", "인증서 자동화 구축기" | sort: "date" -%}
+{% for post in series %}
+1. [{{ post.title }}]({{ post.url | relative_url }})
+{%- endfor %}
+
+### 트립 매니저
+
+바이브코딩으로 만든 코드의 신뢰를 실험하는 시리즈입니다.
+
+{% assign series = site.posts | where: "categories", "트립 매니저" | sort: "date" -%}
+{% for post in series %}
+1. [{{ post.title }}]({{ post.url | relative_url }})
+{%- endfor %}
 
 ## 프로젝트
 
-- [trip-planner](https://github.com/idean3885/trip-planner) - 우리의 여행 앱 만들기 — React + GitHub Pages 모바일 웹
+- [trip-planner](https://github.com/idean3885/trip-planner) - 우리의 여행 앱 만들기. React + GitHub Pages 모바일 웹
 - [claude-devex](https://github.com/idean3885/claude-devex) - AI 기반 개발 사이클 자동화 도구
 - [claude-cross-verify](https://github.com/idean3885/claude-cross-verify) - 의사결정·설계·문서·구현 4축 교차 검증 에이전트
 - [claude-slack-to-notion](https://github.com/idean3885/claude-slack-to-notion) - Slack 스레드를 Notion으로 정리하는 MCP 플러그인


### PR DESCRIPTION
## 작업 내용

홈 페이지(`/`)가 정적 시리즈 목록 위주라 신규 포스트가 발행되어도 갱신 시그널이 부족했고, 시리즈 목록도 stale 상태였다.
최신 포스트 자동화 + PAAR 깊이 기준으로 주요 시리즈 선별하여 갱신 시그널과 깊이 시그널을 모두 확보한다.

## 변경 사항

- 섹션 순서 재배치: 소개 → 최신 포스트 → 주요 시리즈 → 프로젝트 → 링크
- 최신 포스트 5편 Liquid 자동화 (`site.posts | limit:5`)
- 주요 시리즈 4개 선별 (PAAR 깊이 기준):
  - 미터링 시스템 구축 (5편): 분석 깊이 + 시리즈 흐름
  - AI 교차 검증 (4편): 도구 구현 + 회고 마무리
  - 인증서 자동화 구축기 (2편): 압축적 분석
  - 트립 매니저 (1편, 신생): PAAR 명시 작성
- 시리즈별 글 목록도 카테고리 매칭으로 자동화 (`where: "categories", "..."`)
- 탈락: Slack to Notion 제작기 (단계별 경험기), AI 적응기 (시리즈 흐름 약함)

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `bundle exec jekyll build` |
| 최신 포스트 자동화 | ✅ 정상 | 5편 자동 표시 (vibe-coding-defense → cross-verify-3month-retrospective) |
| 시리즈 자동화 | ✅ 정상 | 미터링 5편, AI 교차 검증 4편, 인증서 자동화 2편, 트립 매니저 1편 정확 매핑 |
| 신규 포스트 반영 | ✅ 자동 | 카테고리 매칭으로 신규 글 추가 시 즉시 반영 |
| 반응형 | ✅ 통과 | Chirpy `page` 레이아웃 그대로 사용, 추가 CSS 없음 |

Closes #222
