### PR TITLE
feat: 사이드바 폴딩 토글 + 코드블록 좌측 패딩

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,0 +1,136 @@
+<!-- The Side Bar (project override: adds desktop collapse toggle) -->
+
+<script>
+  (function () {
+    try {
+      if (localStorage.getItem('sidebar-collapsed') === 'true') {
+        document.documentElement.setAttribute('data-sidebar-collapsed', 'true');
+      }
+    } catch (_) {}
+  })();
+</script>
+
+<aside aria-label="Sidebar" id="sidebar" class="d-flex flex-column align-items-end">
+  <header class="profile-wrapper">
+    <a href="{{ '/' | relative_url }}" id="avatar" class="rounded-circle">
+      {%- if site.avatar != empty and site.avatar -%}
+        {%- capture avatar_url -%}
+          {% include media-url.html src=site.avatar %}
+        {%- endcapture -%}
+        <img src="{{- avatar_url -}}" width="112" height="112" alt="avatar" onerror="this.style.display='none'">
+      {%- endif -%}
+    </a>
+
+    <a class="site-title d-block" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+    <p class="site-subtitle fst-italic mb-0">{{ site.tagline }}</p>
+  </header>
+  <!-- .profile-wrapper -->
+
+  <nav class="flex-column flex-grow-1 w-100 ps-0">
+    <ul class="nav">
+      <!-- home -->
+      <li class="nav-item{% if page.layout == 'home' %}{{ " active" }}{% endif %}">
+        <a href="{{ '/' | relative_url }}" class="nav-link">
+          <i class="fa-fw fas fa-home"></i>
+          <span>{{ site.data.locales[include.lang].tabs.home | upcase }}</span>
+        </a>
+      </li>
+      <!-- the real tabs -->
+      {% for tab in site.tabs %}
+        <li class="nav-item{% if tab.url == page.url %}{{ " active" }}{% endif %}">
+          <a href="{{ tab.url | relative_url }}" class="nav-link">
+            <i class="fa-fw {{ tab.icon }}"></i>
+            {% capture tab_name %}{{ tab.url | split: '/' }}{% endcapture %}
+
+            <span>{{ site.data.locales[include.lang].tabs.[tab_name] | default: tab.title | upcase }}</span>
+          </a>
+        </li>
+        <!-- .nav-item -->
+      {% endfor %}
+    </ul>
+  </nav>
+
+  <div class="sidebar-bottom d-flex flex-wrap  align-items-center w-100">
+    {% unless site.theme_mode %}
+      <button type="button" class="btn btn-link nav-link" aria-label="Switch Mode" id="mode-toggle">
+        <i class="fas fa-adjust"></i>
+      </button>
+
+      {% if site.data.contact.size > 0 %}
+        <span class="icon-border"></span>
+      {% endif %}
+    {% endunless %}
+
+    {% for entry in site.data.contact %}
+      {%- assign url = null -%}
+
+      {% case entry.type %}
+        {% when 'github', 'twitter' %}
+          {%- unless site[entry.type].username -%}
+            {%- continue -%}
+          {%- endunless -%}
+          {%- capture url -%}
+            https://{{ entry.type }}.com/{{ site[entry.type].username }}
+          {%- endcapture -%}
+        {% when 'email' %}
+          {%- unless site.social.email -%}
+            {%- continue -%}
+          {%- endunless -%}
+          {%- assign email = site.social.email | split: '@' -%}
+          {%- capture url -%}
+            javascript:location.href = 'mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@')
+          {%- endcapture -%}
+        {% when 'rss' %}
+          {% assign url = '/feed.xml' | relative_url %}
+        {% else %}
+          {% assign url = entry.url %}
+      {% endcase %}
+
+      {% if url %}
+        <a
+          href="{{ url }}"
+          aria-label="{{ entry.type }}"
+          {% assign link_types = '' %}
+
+          {% unless entry.noblank %}
+            target="_blank"
+            {% assign link_types = 'noopener noreferrer' %}
+          {% endunless %}
+
+          {% if entry.type == 'mastodon' %}
+            {% assign link_types = link_types | append: ' me' | strip %}
+          {% endif %}
+
+          {% unless link_types == empty %}
+            rel="{{ link_types }}"
+          {% endunless %}
+        >
+          <i class="{{ entry.icon }}"></i>
+        </a>
+      {% endif %}
+    {% endfor %}
+
+    <button type="button" class="btn btn-link nav-link sidebar-collapse-toggle" aria-label="Toggle sidebar" id="sidebar-collapse-toggle">
+      <i class="fas fa-angle-left"></i>
+    </button>
+  </div>
+  <!-- .sidebar-bottom -->
+</aside>
+<!-- #sidebar -->
+
+<script>
+  (function () {
+    var btn = document.getElementById('sidebar-collapse-toggle');
+    if (!btn) return;
+    btn.addEventListener('click', function () {
+      var isCollapsed = document.documentElement.getAttribute('data-sidebar-collapsed') === 'true';
+      if (isCollapsed) {
+        document.documentElement.removeAttribute('data-sidebar-collapsed');
+        try { localStorage.setItem('sidebar-collapsed', 'false'); } catch (_) {}
+      } else {
+        document.documentElement.setAttribute('data-sidebar-collapsed', 'true');
+        try { localStorage.setItem('sidebar-collapsed', 'true'); } catch (_) {}
+      }
+    });
+  })();
+</script>

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -122,6 +122,125 @@ h1, h2, h3, h4, h5 {
   }
 }
 
+/* === Sidebar Collapse (desktop only, lg breakpoint 이상) === */
+
+/* 접힘 상태 토글 버튼 — 기본 상태(펼침)에서 '<' 아이콘 */
+#sidebar-collapse-toggle {
+  margin-left: auto; /* sidebar-bottom 우측 정렬 */
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+
+  i {
+    transition: transform 0.25s ease;
+  }
+}
+
+/* 모바일(<lg)에서는 데스크톱 전용 토글 숨김 — 햄버거 메뉴 유지 */
+@media (max-width: 849px) {
+  #sidebar-collapse-toggle {
+    display: none;
+  }
+}
+
+/* lg 이상에서만 접힘/펼침 폭 전환을 애니메이션 */
+@media (min-width: 850px) {
+  #sidebar,
+  #main-wrapper {
+    transition: width 0.25s ease, margin-left 0.25s ease;
+  }
+}
+
+/* 접힘 상태: 아이콘만 표시, 폭 축소 */
+html[data-sidebar-collapsed='true'] {
+  @media (min-width: 850px) {
+    #sidebar {
+      width: 5rem;
+
+      .site-title,
+      .site-subtitle {
+        display: none;
+      }
+
+      .profile-wrapper {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+        margin-top: 1.75rem;
+        margin-bottom: 1.75rem;
+      }
+
+      #avatar {
+        width: 3rem;
+        height: 3rem;
+
+        @media (min-width: 576px) {
+          width: 3rem;
+          height: 3rem;
+        }
+      }
+
+      ul li.nav-item {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+
+        a.nav-link {
+          justify-content: center;
+
+          i {
+            margin-right: 0;
+          }
+
+          span {
+            display: none;
+          }
+        }
+      }
+
+      .sidebar-bottom {
+        justify-content: center;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+
+        > a,
+        > #mode-toggle,
+        > .icon-border {
+          display: none;
+        }
+      }
+
+      #sidebar-collapse-toggle {
+        margin-left: 0;
+        display: flex;
+
+        i {
+          transform: rotate(180deg); /* 접힘 상태에서 '>' 방향 */
+        }
+      }
+    }
+
+    #main-wrapper {
+      margin-left: 5rem;
+    }
+  }
+
+  @media (min-width: 1650px) {
+    #main-wrapper {
+      margin-left: 5rem;
+    }
+  }
+}
+
+/* === 코드블록 좌측 패딩 === */
+/* Rouge non-lineno 출력(`<div class="highlight"><pre><code>`)은
+   기본 좌측 패딩이 없어 텍스트가 경계에 붙는다.
+   lineno 모드와 시각적 여백을 맞춘다. */
+.highlight {
+  pre {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
 /* toc-bar: 축소 화면에서 불필요 — 스크롤 프로그레스로 대체 */
 #toc-bar {
   display: none !important;


### PR DESCRIPTION
## Summary
- 데스크톱 사이드바를 2단계(펼침/접힘)로 토글, 상태는 localStorage에 영속화
- 접힘 시 폭 5rem, 라벨/사이트명/서브타이틀 숨김, 아바타·프로필 축소
- 모바일(<850px)은 기존 햄버거 슬라이드 동작 그대로, 토글 버튼은 숨김
- 비-lineno 코드블록(`.highlight pre`)에 좌측 패딩 1rem 부여 — 텍스트가 경계에 붙던 문제 해소

Closes #241

## Test plan
- [x] `bundle exec jekyll build` 성공, SCSS 컴파일 산출물에 `html[data-sidebar-collapsed=true]` 규칙 포함
- [x] 컴파일된 CSS에 `.highlight pre{padding-left:1rem;padding-right:1rem}` 포함
- [x] 로컬 서버(`:4001`) 기동 후 `/` 응답 HTML에 `#sidebar-collapse-toggle` 버튼 + 조기 초기화 스크립트 확인
- [ ] 데스크톱에서 토글 클릭 시 폭/라벨/아바타 축소 (사용자 검증)
- [ ] 새로고침 후 접힘 상태 유지 (사용자 검증)
- [ ] 모바일 폭에서 기존 햄버거 메뉴 정상 (사용자 검증)
- [ ] 기존 포스트 코드블록 좌측 여백 확인 (사용자 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)