### PR TITLE
docs: 메인에 '추천 글' 섹션 신설 (핀 고정 글 노출)

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,6 +29,15 @@ GPU 기반 PaaS·시계열 파이프라인·자동화 시스템 사례를
 
 </div>
 
+## 추천 글
+
+의사결정과 트레이드오프의 흔적이 가장 잘 드러난 글입니다.
+
+{% assign pinned = site.posts | where: "pin", true | sort: "date" | reverse %}
+{% for post in pinned %}
+1. [{{ post.title }}]({{ post.url | relative_url }})
+{%- endfor %}
+
 ## 최신 포스트
 
 {% for post in site.posts limit:5 %}


### PR DESCRIPTION
## Summary

- 커스텀 `index.md`(layout: page)에서 Chirpy 기본 핀 영역이 작동하지 않는 문제 해결
- Liquid로 `site.posts where pin == true` 직접 노출
- 메인 첫 인상에 의사결정·트레이드오프 대표 글 5건이 우선 노출

## 변경

- `index.md` 소개 직후, 최신 포스트 위에 "추천 글" 섹션 추가
- 핀 고정된 5건 자동 표시 (front-matter `pin: true`)

## 표시 순서 (메인)

1. 소개
2. **추천 글** (신설, 핀 고정 5건)
3. 최신 포스트
4. 주요 시리즈
5. 도구·방법론

Closes follow-up of #250