### PR TITLE
fix(256): 사이드바 collapsed 영구 저장 제거 + xl 이상 자동 펼침

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,15 +1,5 @@
 <!-- The Side Bar (project override: adds desktop collapse toggle) -->
 
-<script>
-  (function () {
-    try {
-      if (localStorage.getItem('sidebar-collapsed') === 'true') {
-        document.documentElement.setAttribute('data-sidebar-collapsed', 'true');
-      }
-    } catch (_) {}
-  })();
-</script>
-
 <aside aria-label="Sidebar" id="sidebar" class="d-flex flex-column align-items-end">
   <header class="profile-wrapper">
     <a href="{{ '/' | relative_url }}" id="avatar" class="rounded-circle">
@@ -123,16 +113,16 @@
   (function () {
     var btn = document.getElementById('sidebar-collapse-toggle');
     if (!btn) return;
+    // 이전 버전에서 영구 저장된 collapsed 상태 정리
+    try { localStorage.removeItem('sidebar-collapsed'); } catch (_) {}
     btn.addEventListener('click', function () {
-      // 태블릿 이하에서는 미디어쿼리가 상태를 강제하므로 토글 무효화
-      if (window.innerWidth < 850) return;
+      // lg(850-1199)에서만 토글 동작. xl 이상에서는 사이드바가 항상 펴짐.
+      if (window.innerWidth < 850 || window.innerWidth >= 1200) return;
       var isCollapsed = document.documentElement.getAttribute('data-sidebar-collapsed') === 'true';
       if (isCollapsed) {
         document.documentElement.removeAttribute('data-sidebar-collapsed');
-        try { localStorage.setItem('sidebar-collapsed', 'false'); } catch (_) {}
       } else {
         document.documentElement.setAttribute('data-sidebar-collapsed', 'true');
-        try { localStorage.setItem('sidebar-collapsed', 'true'); } catch (_) {}
       }
     });
   })();

--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -13,8 +13,9 @@
   }
   /* 사이드바 표시 시 사이드바 너비만큼 왼쪽 오프셋
      — 576-849: 5rem 고정(토글 불가)
-     — ≥850: 기본 260px, 접힘 시 5rem
-     — ≥1650: 기본 300px, 접힘 시 5rem */
+     — 850-1199: 기본 260px, 접힘 시 5rem
+     — ≥1200: 기본 260px, 접힘 무효(사이드바 항상 펴짐)
+     — ≥1650: 사이드바가 300px로 확장 */
   @media (min-width: 576px) and (max-width: 849px) {
     #topbar-wrapper {
       left: 5rem;
@@ -24,6 +25,8 @@
     #topbar-wrapper {
       left: 260px;
     }
+  }
+  @media (min-width: 850px) and (max-width: 1199px) {
     html[data-sidebar-collapsed="true"] #topbar-wrapper {
       left: 5rem;
     }
@@ -31,9 +34,6 @@
   @media (min-width: 1650px) {
     #topbar-wrapper {
       left: 300px;
-    }
-    html[data-sidebar-collapsed="true"] #topbar-wrapper {
-      left: 5rem;
     }
   }
   /* topbar 높이만큼 본문 여백 확보 */
@@ -58,6 +58,8 @@
     #reading-progress-wrap {
       left: 260px;
     }
+  }
+  @media (min-width: 850px) and (max-width: 1199px) {
     html[data-sidebar-collapsed="true"] #reading-progress-wrap {
       left: 5rem;
     }
@@ -65,9 +67,6 @@
   @media (min-width: 1650px) {
     #reading-progress-wrap {
       left: 300px;
-    }
-    html[data-sidebar-collapsed="true"] #reading-progress-wrap {
-      left: 5rem;
     }
   }
   #reading-progress {

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -167,8 +167,8 @@ h1, h2, h3, h4, h5 {
   }
 }
 
-/* lg 이상(>=850px)에서만 표시/애니메이션 */
-@media (min-width: 850px) {
+/* lg(850-1199)에서만 토글 표시/애니메이션 — xl 이상에서는 사이드바 항상 펴짐 */
+@media (min-width: 850px) and (max-width: 1199px) {
   #sidebar,
   #main-wrapper {
     transition: width 0.25s ease, margin-left 0.25s ease;
@@ -181,16 +181,9 @@ h1, h2, h3, h4, h5 {
   }
 }
 
-/* xxxl(>=1650px)에서 sidebar 폭이 300px로 확장 — 토글 위치도 보정 */
-@media (min-width: 1650px) {
-  #sidebar-collapse-toggle {
-    left: calc(300px - 0.75rem);
-  }
-}
-
-/* 접힘 상태(data-sidebar-collapsed=true) — ≥850px에서 사용자가 토글로 접은 경우 */
+/* 접힘 상태(data-sidebar-collapsed=true) — lg(850-1199) 좁은 데스크톱에서만 적용 */
 html[data-sidebar-collapsed='true'] {
-  @media (min-width: 850px) {
+  @media (min-width: 850px) and (max-width: 1199px) {
     #sidebar {
       width: 5rem;
 
@@ -237,16 +230,6 @@ html[data-sidebar-collapsed='true'] {
       i {
         transform: rotate(180deg);
       }
-    }
-  }
-
-  @media (min-width: 1650px) {
-    #main-wrapper {
-      margin-left: 5rem;
-    }
-
-    #sidebar-collapse-toggle {
-      left: calc(5rem - 0.75rem);
     }
   }
 }


### PR DESCRIPTION
Fix #256

## Summary
- 가로 폭 1200px 이상에서도 좌측 사이드바가 접힌 채 유지되는 버그 수정.
- localStorage에 영구 저장되던 `sidebar-collapsed` 상태 제거.

## 변경 내용
- `_includes/sidebar.html`: 페이지 로드 시 localStorage 읽기 IIFE 제거. 토글 핸들러에서도 영구 저장 제거. 이전 버전에서 저장된 키는 자동 정리.
- `assets/css/jekyll-theme-chirpy.scss`: collapsed 효과를 lg(850-1199) 범위로 한정. xxxl(1650+) 분기 제거.
- `_includes/topbar.html`: topbar/reading-progress의 collapsed 보정도 lg(850-1199)로 한정.

## 동작 매트릭스
| 폭 | 사이드바 |
|---|---|
| <576 | chirpy 기본 (햄버거 토글, 평소 숨김) |
| 576-849 | 5rem 강제 (토글 비활성, 기존 동일) |
| 850-1199 | 토글로 접기/펴기 가능 (collapsed 시 5rem) |
| ≥1200 | **항상 펼침** (collapsed attribute 무시) |
| ≥1650 | 사이드바 300px (chirpy 기본) |

## Test plan
- [x] 로컬 빌드 성공 (`bundle exec jekyll build`)
- [x] 빌드된 CSS에서 collapsed 미디어쿼리가 lg 범위로 한정 확인
- [x] 빌드된 sidebar.html에서 localStorage 영구 저장 코드 제거 확인
- [ ] 머지 후 GitHub Actions 배포 성공 확인
- [ ] 라이브 사이트(blog.idean.me)에서 가로 1200px+ 사이드바 항상 펼침 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)