### PR TITLE
fix(258): 모든 데스크톱에서 사이드바 토글 표시 + 클릭 동작 보장

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -116,8 +116,8 @@
     // 이전 버전에서 영구 저장된 collapsed 상태 정리
     try { localStorage.removeItem('sidebar-collapsed'); } catch (_) {}
     btn.addEventListener('click', function () {
-      // lg(850-1199)에서만 토글 동작. xl 이상에서는 사이드바가 항상 펴짐.
-      if (window.innerWidth < 850 || window.innerWidth >= 1200) return;
+      // 데스크톱(>=850)에서만 토글 동작. 그 미만에서는 미디어쿼리가 상태를 강제.
+      if (window.innerWidth < 850) return;
       var isCollapsed = document.documentElement.getAttribute('data-sidebar-collapsed') === 'true';
       if (isCollapsed) {
         document.documentElement.removeAttribute('data-sidebar-collapsed');

--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -13,9 +13,8 @@
   }
   /* 사이드바 표시 시 사이드바 너비만큼 왼쪽 오프셋
      — 576-849: 5rem 고정(토글 불가)
-     — 850-1199: 기본 260px, 접힘 시 5rem
-     — ≥1200: 기본 260px, 접힘 무효(사이드바 항상 펴짐)
-     — ≥1650: 사이드바가 300px로 확장 */
+     — ≥850: 기본 260px, 접힘 시 5rem
+     — ≥1650: 기본 300px, 접힘 시 5rem */
   @media (min-width: 576px) and (max-width: 849px) {
     #topbar-wrapper {
       left: 5rem;
@@ -25,8 +24,6 @@
     #topbar-wrapper {
       left: 260px;
     }
-  }
-  @media (min-width: 850px) and (max-width: 1199px) {
     html[data-sidebar-collapsed="true"] #topbar-wrapper {
       left: 5rem;
     }
@@ -34,6 +31,9 @@
   @media (min-width: 1650px) {
     #topbar-wrapper {
       left: 300px;
+    }
+    html[data-sidebar-collapsed="true"] #topbar-wrapper {
+      left: 5rem;
     }
   }
   /* topbar 높이만큼 본문 여백 확보 */
@@ -58,8 +58,6 @@
     #reading-progress-wrap {
       left: 260px;
     }
-  }
-  @media (min-width: 850px) and (max-width: 1199px) {
     html[data-sidebar-collapsed="true"] #reading-progress-wrap {
       left: 5rem;
     }
@@ -67,6 +65,9 @@
   @media (min-width: 1650px) {
     #reading-progress-wrap {
       left: 300px;
+    }
+    html[data-sidebar-collapsed="true"] #reading-progress-wrap {
+      left: 5rem;
     }
   }
   #reading-progress {

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -145,7 +145,8 @@ h1, h2, h3, h4, h5 {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 2px 8px rgba(0, 0, 0, 0.04);
   color: #6b7280;
   font-size: 0.7rem;
-  z-index: 1030;
+  z-index: 1050;
+  isolation: isolate; /* hit-test가 다른 요소에 가로채지지 않도록 stacking context 강제 */
   cursor: pointer;
   transition: left 0.25s ease, background-color 0.15s ease, color 0.15s ease,
     box-shadow 0.15s ease;
@@ -167,8 +168,8 @@ h1, h2, h3, h4, h5 {
   }
 }
 
-/* lg(850-1199)에서만 토글 표시/애니메이션 — xl 이상에서는 사이드바 항상 펴짐 */
-@media (min-width: 850px) and (max-width: 1199px) {
+/* 데스크톱(>=850px)에서 토글 표시/애니메이션 */
+@media (min-width: 850px) {
   #sidebar,
   #main-wrapper {
     transition: width 0.25s ease, margin-left 0.25s ease;
@@ -181,9 +182,16 @@ h1, h2, h3, h4, h5 {
   }
 }
 
-/* 접힘 상태(data-sidebar-collapsed=true) — lg(850-1199) 좁은 데스크톱에서만 적용 */
+/* xxxl(>=1650px)에서 sidebar 폭이 300px로 확장 — 토글 위치 보정 */
+@media (min-width: 1650px) {
+  #sidebar-collapse-toggle {
+    left: calc(300px - 0.75rem);
+  }
+}
+
+/* 접힘 상태(data-sidebar-collapsed=true) — 데스크톱에서 사용자가 토글로 접은 경우 */
 html[data-sidebar-collapsed='true'] {
-  @media (min-width: 850px) and (max-width: 1199px) {
+  @media (min-width: 850px) {
     #sidebar {
       width: 5rem;
 
@@ -230,6 +238,16 @@ html[data-sidebar-collapsed='true'] {
       i {
         transform: rotate(180deg);
       }
+    }
+  }
+
+  @media (min-width: 1650px) {
+    #main-wrapper {
+      margin-left: 5rem;
+    }
+
+    #sidebar-collapse-toggle {
+      left: calc(5rem - 0.75rem);
     }
   }
 }


### PR DESCRIPTION
Fix #258

## Summary
- xl/xxxl 등 모든 데스크톱 폭(>=850px)에서 토글 보임 + 클릭 동작.
- 토글 z-index 1030→1050 + isolation:isolate로 hit-test 안전성 확보.
- localStorage 영구 저장 미사용은 #257 그대로 유지.

## 변경 내용
- `_includes/sidebar.html`: JS의 xl 이상 가드(`>= 1200`) 제거. 모든 데스크톱에서 토글 작동.
- `assets/css/jekyll-theme-chirpy.scss`:
  - 토글 표시 미디어쿼리: `(min-width:850px) and (max-width:1199px)` → `(min-width:850px)`
  - 토글 `z-index: 1050` + `isolation: isolate`
  - collapsed 효과 적용 범위 데스크톱 전체로 환원, xxxl(1650+) 보정 복원
- `_includes/topbar.html`: topbar/reading-progress의 collapsed 보정도 850+/1650+로 환원

## 동작 매트릭스
| 폭 | 사이드바 | 토글 |
|---|---|---|
| <576 | chirpy 기본(햄버거) | 숨김 |
| 576-849 | 5rem 강제 | 시각 표시, 클릭 비활성 |
| ≥850 | 기본 260px, 접힘 시 5rem | 표시 + 작동 |
| ≥1650 | 기본 300px, 접힘 시 5rem | 표시 + 작동 |

## Test plan
- [x] 로컬 빌드 성공
- [x] 빌드된 CSS에 `z-index:1050`, `isolation:isolate` 확인
- [x] 토글 display:flex가 `@media (min-width: 850px)` 전체에 적용됨 확인
- [ ] 머지 후 GitHub Actions 배포 성공
- [ ] 라이브 사이트에서 1200+/1650+ 모두 토글 보임 확인
- [ ] 라이브 사이트에서 토글 클릭으로 사이드바 접기/펴기 동작 확인
- [ ] 새로고침 시 사이드바 펴진 상태로 시작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)