### PR TITLE
fix: 사이드바 토글 회귀 진짜 원인 — 인라인 스크립트 // 주석 제거 (#260)

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -110,13 +110,13 @@
 </button>
 
 <script>
+  /* compress 레이아웃이 줄바꿈을 제거하므로 인라인 스크립트는 // 한 줄 주석을 쓰지 않는다.
+     쓰면 이후 코드가 모두 주석으로 흡수되어 IIFE가 닫히지 않는다 (이슈 #260). */
   (function () {
     var btn = document.getElementById('sidebar-collapse-toggle');
     if (!btn) return;
-    // 이전 버전에서 영구 저장된 collapsed 상태 정리
     try { localStorage.removeItem('sidebar-collapsed'); } catch (_) {}
     btn.addEventListener('click', function () {
-      // 데스크톱(>=850)에서만 토글 동작. 그 미만에서는 미디어쿼리가 상태를 강제.
       if (window.innerWidth < 850) return;
       var isCollapsed = document.documentElement.getAttribute('data-sidebar-collapsed') === 'true';
       if (isCollapsed) {


### PR DESCRIPTION
## 작업 내용
이슈 #260 사이드바 토글 회귀의 실제 원인을 파악하고 수정한다. #257/#258 두 차례의 핫픽스가 모두 CSS hit-test 가설을 다뤘으나 증상은 사라지지 않았다. 라이브 사이트를 헤드리스 브라우저로 재현해 콘솔 에러 `Unexpected end of input`을 확인했고, `_includes/sidebar.html` 인라인 스크립트의 `//` 주석이 원인이었다.

## 원인
`_layouts/compress.html`이 빌드 시 줄바꿈을 제거한다. 인라인 `<script>` 안에 `//` 한 줄 주석이 있으면 압축 후 한 줄이 되면서 주석 뒤의 코드(IIFE 본문 전체)가 모두 주석으로 흡수된다. 결과적으로 IIFE가 닫히지 않아 JS 파서가 `Unexpected end of input` 에러를 던지고, `addEventListener`가 등록되지 않아 토글 클릭이 무반응이 된다.

## 변경 사항
- `_includes/sidebar.html`: 인라인 스크립트 안의 `//` 한 줄 주석 2개 제거
- 회귀 방지를 위해 원인을 설명하는 블록 주석(`/* */`)을 스크립트 상단에 명시

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `JEKYLL_ENV=production bundle exec jekyll build` |
| 회귀 재현 | ✅ 라이브 재현 | Playwright 1700px → 클릭 후 `data-sidebar-collapsed`가 그대로 null, `pageerror: Unexpected end of input` 1건 |
| 수정 검증 | ✅ 4폭 통과 | production-compressed 빌드 기준 900/1100/1500/1700 모두 collapse(80px)+expand(원복) 정상, JS 에러 0 |
| 인라인 스크립트 압축 결과 | ✅ 확인 | 압축 후 IIFE `})();` 까지 보존되며 `//` 토큰 없음 |

## 회고
콘솔 에러를 확인하지 않은 채 CSS 가설만 두 차례 시도했다. 다음 핫픽스 시 라이브 환경에서 DevTools Console / 헤드리스 `pageerror`를 1회 이상 점검한다.

Closes #260