### PR TITLE
chore: 사이드바 토글 hit-test 가설 흔적 정리 (#266)

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -145,8 +145,7 @@ h1, h2, h3, h4, h5 {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 2px 8px rgba(0, 0, 0, 0.04);
   color: #6b7280;
   font-size: 0.7rem;
-  z-index: 1050;
-  isolation: isolate; /* hit-test가 다른 요소에 가로채지지 않도록 stacking context 강제 */
+  z-index: 1030;
   cursor: pointer;
   transition: left 0.25s ease, background-color 0.15s ease, color 0.15s ease,
     box-shadow 0.15s ease;


### PR DESCRIPTION
## 작업 내용
PR #265에서 사이드바 토글 회귀의 실 원인이 인라인 스크립트의 `//` 주석임이 확인되었다. #258이 잘못된 hit-test 가설로 추가했던 CSS 강화는 더 이상 필요하지 않으므로 정리한다.

## 변경 사항
- `assets/css/jekyll-theme-chirpy.scss`: `#sidebar-collapse-toggle`
  - `z-index: 1050` → `1030` 환원 (#258 이전 값, 토픽바 1020 위로 충분)
  - `isolation: isolate;` + 인라인 주석 제거

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `JEKYLL_ENV=production bundle exec jekyll build` |
| 토글 동작 회귀 | ✅ 4폭 통과 | production-compressed 빌드 기준 900/1100/1500/1700 모두 collapse(80px) + expand 정상 |
| computed CSS | ✅ 환원 확인 | `z-index: 1030`, `isolation: auto` |
| JS 에러 | ✅ 0건 | Playwright pageerror 미발생 |

Closes #266