### PR TITLE
fix: GSC 사이트맵을 posts로 슬림화 - thin content 색인 거부 해결

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,6 +1,7 @@
 ---
+permalink: /robots.txt
 layout: null
 ---
 User-agent: *
 Allow: /
-Sitemap: https://blog.idean.me/sitemap-manual.xml
+Sitemap: {{ '/sitemap.xml' | absolute_url }}

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,0 @@
----
-layout: null
----
-User-agent: *
-Allow: /
-Sitemap: https://blog.idean.me/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,22 @@
+---
+layout: null
+permalink: /sitemap.xml
+sitemap: false
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+        xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- assign posts = site.posts | where_exp: "post", "post.sitemap != false" -%}
+  {%- for post in posts %}
+  <url>
+    <loc>{{ post.url | absolute_url | xml_escape }}</loc>
+    {%- if post.last_modified_at or post.date %}
+    <lastmod>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</lastmod>
+    {%- endif %}
+  </url>
+  {%- endfor %}
+  <url>
+    <loc>{{ '/' | absolute_url | xml_escape }}</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## 작업 내용

GSC \"크롤링됨 - 현재 색인이 생성되지 않음\" 113건 중 약 85건이 `jekyll-archives`가 생성하는 tags/categories 페이지(thin content)와 탭 메타 페이지로 인한 거부였음. 사이트맵을 posts만 포함하도록 직접 작성하여 GSC 추적 대상에서 제거.

## 변경 사항

- **`sitemap.xml` 신규**: posts 전용 사이트맵 (Liquid 템플릿). `jekyll-sitemap`이 이미 존재하는 `sitemap.xml`을 감지하면 자동 생성을 건너뛴다
- **루트 `robots.txt` 제거**: `assets/robots.txt`와 출력 경로 충돌, 단일화
- **`assets/robots.txt` 정정**: `permalink` 명시, dead 링크 `sitemap-manual.xml`을 유효한 `sitemap.xml`로 변경

## 시도와 결정 기록

처음엔 `_config.yml`의 `defaults`에 `type: tag`, `type: category`로 `sitemap: false`를 매기는 방법을 시도했으나, `jekyll-archives`의 `Archive` 클래스가 `Jekyll::Page`를 상속하지만 frontmatter defaults 매칭이 동작하지 않아 사이트맵 제외 효과가 없었음 (78개 tags + 15개 categories 그대로 포함).

`sitemap.xml`을 직접 작성하면 `jekyll-sitemap`이 자동 생성을 건너뛰므로 가장 단순하고 통제 가능한 방법.

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | \`JEKYLL_ENV=production bundle exec jekyll build\` 정상 완료 |
| 사이트맵 슬림화 | ✅ 통과 | URL 118 → 24 (posts 23 + 홈 1). tags/categories 0 |
| robots.txt 정합성 | ✅ 통과 | \`User-agent: * / Allow: / / Sitemap: https://blog.idean.me/sitemap.xml\` (live와 동일) |
| 테스트 | ⬜ 해당없음 | 정적 사이트 빌드 검증으로 대체 |
| 문서 동기화 | ⬜ 해당없음 | CLAUDE.md 영향 없음 |

## 기대 효과

- GSC 거부 카운트 113 → 약 30건(살아있는 posts 10 + 삭제 posts 20)으로 축소
- 카테고리/태그 페이지는 어차피 거부 상태였으므로 검색 노출 손실 없음

## 후속

- Step 2: `jekyll-redirect-from` 도입 + 삭제 20개 posts redirect 매핑 (별도 이슈)
- Step 3: 2~4주 lastmod 안정화 후 사용자가 GSC에서 유효성 검사 재시작

Closes #298