### PR TITLE
refactor: 홈 화면 추천 글 - 주요 시리즈 중복 4건 제거 + 시리즈 인덱스 소개 보강

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,24 +31,16 @@ GPU 기반 PaaS·시계열 파이프라인·인증서 자동화 같은
 
 ## 추천 글
 
-최근 자주 다시 펼쳐보는 글입니다.
-
-### 데이터 정합성과 트레이드오프
-
-- [어디까지 견뎌야 하는가 - 미터링 용량을 세 가지 제약으로 역산한 의사결정](/posts/metering-capacity-triple-constraint/)
-- [미터링 배치 시스템 설계: 쓰기 경합·청사진·패턴 명명·저장 전략 통일까지](/posts/metering-batch-system-design/)
-- [MySQL 파티셔닝 도입기: JPA 복합 키 전환부터 시간 독립 DDL까지](/posts/mysql-partitioning-jpa-composite-key/)
-
-### 무중단 운영과 자동화
+시리즈에 묶이지 않은 단독 글입니다.
 
 - [Expand-and-Contract 패턴: 무중단 DB 스키마 변경을 3단계 PR로 분할하기](/posts/expand-and-contract-pattern/)
-- [인증서 자동화: 사용자 도메인 ACME4j 구현부터 와일드카드 Jenkins 갱신까지](/posts/cert-automation-acme-and-wildcard/)
 
 ## 주요 시리즈
 
 ### 미터링 시스템 구축
 
 GPU 클라우드 서비스의 사용량 수집·집계 시스템을 설계하고 구현한 과정입니다.
+쓰기 경합·용량 트레이드오프·저장 전략 통일 같은 데이터 정합성 결정을 다룹니다.
 
 {% assign series = site.posts | where: "categories", "미터링 시스템 구축" | sort: "date" -%}
 {% for post in series %}
@@ -57,7 +49,8 @@ GPU 클라우드 서비스의 사용량 수집·집계 시스템을 설계하고
 
 ### 인증서 자동화 구축기
 
-사용자 도메인 인증서 발급·갱신을 완전 자동화한 과정입니다.
+사용자 도메인 인증서 발급·갱신을 무중단으로 자동화한 과정입니다.
+ACME 프로토콜 학습·헥사고날 상태 머신·Jenkins 격월 크론으로 운영 부담을 끊었습니다.
 
 {% assign series = site.posts | where: "categories", "인증서 자동화 구축기" | sort: "date" -%}
 {% for post in series %}


### PR DESCRIPTION
## 작업 내용

홈 화면 추천 글 5건 중 4건이 주요 시리즈 Liquid 인덱스와 100% 중복 노출되고 있었다. 큐레이션 가치가 시리즈 인덱스의 부분집합이 되어 수동 관리 비용만 추가된 상태. 추천 글은 시리즈에 묶이지 않은 단독 글만 노출하고, 시리즈 인덱스 소개 문구로 데이터 정합성·무중단 운영 thematic 안내를 흡수한다.

## 변경 사항

### 1) 추천 글 5건 → 1건

- 데이터 정합성과 트레이드오프 서브섹션 제거 (미터링 3건 모두 시리즈 중복)
- 무중단 운영과 자동화 서브섹션 제거 (인증서 자동화 1건 시리즈 중복)
- Expand-and-Contract 패턴 1건만 본문에 직접 노출 (어느 시리즈에도 묶이지 않은 단독 글)
- 도입 문구: "최근 자주 다시 펼쳐보는 글" → "시리즈에 묶이지 않은 단독 글"

### 2) 주요 시리즈 인덱스 소개 문구 보강

| 시리즈 | 추가 라인 |
|--------|-----------|
| 미터링 시스템 구축 | 쓰기 경합·용량 트레이드오프·저장 전략 통일 같은 데이터 정합성 결정을 다룹니다 |
| 인증서 자동화 구축기 | ACME 프로토콜 학습·헥사고날 상태 머신·Jenkins 격월 크론으로 운영 부담을 끊었습니다 ("완전 자동화" → "무중단 자동화" 로 thematic 정렬) |
| AI 교차 검증 | 기존 문구 유지 |

## 효과

- 신규 글 발행 시 시리즈 인덱스에 자동 반영, 수동 추천 글 갱신 부담 ↓
- 같은 화면에서 같은 글 두 번 노출되는 중복 해소

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 정적 콘텐츠 변경, GitHub Pages CI 자동 검증 |
| 테스트 | ⬜ 해당없음 | 정적 사이트 |
| 문서 동기화 | ✅ 완료 | Liquid 인덱스 카테고리 매칭 변경 없음 (소개 문구만 추가) |
| AI 티 검증 | ✅ PASS | 추가 4줄 S1 패턴 0건 |
| 중복 해소 | ✅ 5건 → 1건 | 시리즈 인덱스와 겹치는 4건 모두 제거 |

Closes #307