### PR TITLE
fix: 카테고리 페이지 - 하위 없는 카테고리도 글 목록 펼침 (#327)

### DIFF
--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -104,28 +104,22 @@ layout: page
         </span>
 
         <!-- arrow -->
-        {% if sub_categories_size > 0 %}
-          <a
-            href="#{{ LIST_PREFIX }}{{ group_index }}"
-            data-bs-toggle="collapse"
-            aria-expanded="true"
-            aria-label="{{ HEAD_PREFIX }}{{ group_index }}-trigger"
-            class="category-trigger hide-border-bottom"
-          >
-            <i class="fas fa-fw fa-angle-down"></i>
-          </a>
-        {% else %}
-          <span data-bs-toggle="collapse" class="category-trigger hide-border-bottom disabled">
-            <i class="fas fa-fw fa-angle-right"></i>
-          </span>
-        {% endif %}
+        <a
+          href="#{{ LIST_PREFIX }}{{ group_index }}"
+          data-bs-toggle="collapse"
+          aria-expanded="true"
+          aria-label="{{ HEAD_PREFIX }}{{ group_index }}-trigger"
+          class="category-trigger hide-border-bottom"
+        >
+          <i class="fas fa-fw fa-angle-down"></i>
+        </a>
       </div>
       <!-- .card-header -->
 
-      <!-- Sub-categories -->
-      {% if sub_categories_size > 0 %}
-        <div id="{{ LIST_PREFIX }}{{ group_index }}" class="collapse show" aria-expanded="true">
-          <ul class="list-group">
+      <!-- Sub-categories or posts -->
+      <div id="{{ LIST_PREFIX }}{{ group_index }}" class="collapse show" aria-expanded="true">
+        <ul class="list-group">
+          {% if sub_categories_size > 0 %}
             {% for sub_category in sub_categories %}
               <li class="list-group-item">
                 <i class="far fa-folder fa-fw"></i>
@@ -151,9 +145,16 @@ layout: page
                 </span>
               </li>
             {% endfor %}
-          </ul>
-        </div>
-      {% endif %}
+          {% else %}
+            {% for post in posts_of_category %}
+              <li class="list-group-item">
+                <i class="far fa-file fa-fw"></i>
+                <a href="{{ post.url | relative_url }}" class="mx-2">{{ post.title }}</a>
+              </li>
+            {% endfor %}
+          {% endif %}
+        </ul>
+      </div>
     </div>
     <!-- .card -->
 


### PR DESCRIPTION
하위 카테고리 없는 항목의 disabled 화살표를 정상 trigger로 통합하고, collapse 영역에 글 목록을 렌더. 단일 카테고리도 펼치면 글이 보이고 제목 클릭 시 글로 이동.

Closes #327