### PR TITLE
fix: 탑바 backdrop blur 추가 + 우측 패널 sticky 탑바 침범 수정

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -9,7 +9,15 @@
     right: 0;
     z-index: 1020;
     background-color: var(--topbar-bg, var(--body-bg, #fff));
+    /* 반투명 배경 뒤로 스크롤되는 콘텐츠를 흐리게 처리 (프로스티드 글래스) */
+    -webkit-backdrop-filter: blur(10px);
+    backdrop-filter: blur(10px);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  }
+  /* 우측 패널 sticky 고정 위치를 탑바(높이 3rem) 아래로 내려
+     반투명 탑바를 통해 패널 카드가 비치는 침범 현상 방지 */
+  #panel-wrapper .access {
+    top: 3.5rem;
   }
   /* 사이드바 표시 시 사이드바 너비만큼 왼쪽 오프셋
      — 576-849: 5rem 고정(토글 불가)


### PR DESCRIPTION
## 작업 내용
탑바(`#topbar-wrapper`)는 배경이 반투명(`rgb(255 255 255 / 70%)`)인데 `backdrop-filter`가 없어 뒤 콘텐츠가 흐려지지 않고 그대로 비쳤다. 또 우측 패널(`.access`)이 sticky `top: 2rem`(32px)로 탑바 영역(0~48px) 안쪽에 고정되어, 반투명 탑바를 통해 "Recently Updated" 카드가 비쳐 침범처럼 보였다.

## 변경 사항
- `#topbar-wrapper`에 `backdrop-filter: blur(10px)` (+ `-webkit-` 프리픽스) 추가 → 프로스티드 글래스
- `#panel-wrapper .access` sticky `top`을 `3.5rem`(56px)로 내려 탑바(48px) 아래 고정, 침범 제거

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `jekyll serve` 정상 빌드/서빙 |
| 시각 검증 (라이트) | ✅ 통과 | 스크롤 시 콘텐츠 블러 + 패널 침범 없음 |
| 시각 검증 (다크) | ✅ 통과 | `backdrop-filter: blur(10px)`, `.access top 56px` 적용 확인 |
| 테스트 | ⬜ 해당없음 | 정적 사이트, 테스트 스위트 없음 |

Closes #332