### PR TITLE
chore: pages-deploy 액션 Node 24 지원 버전으로 업그레이드

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -44,7 +44,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "_site${{ steps.pages.outputs.base_path }}"
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 작업 내용
GitHub Actions 러너의 Node 20 deprecation(2026-06-16 기본 Node 24 강제, 2026-09-16 Node 20 제거)에 대응해, `pages-deploy.yml`의 각 액션을 Node 24 런타임 최신 메이저로 업그레이드한다.

## 변경 사항
| 액션 | 이전 | 변경 | 런타임 |
|------|------|------|--------|
| `actions/checkout` | `v4` | `v6` | node24 |
| `actions/configure-pages` | `v4` | `v6` | node24 |
| `actions/upload-pages-artifact` | `v3` | `v5` | composite (내부 `upload-artifact@v7`, node24) |
| `actions/deploy-pages` | `v4` | `v5` | node24 |
| `ruby/setup-ruby` | `v1` | 유지 | 메이저 핀, 자동 추종 |

각 액션 최신 메이저의 `action.yml` `runs.using`이 `node24`임을 API로 확인했다.

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| YAML 유효성 | ✅ 통과 | `ruby -ryaml YAML.load_file` OK |
| 액션 런타임 확인 | ✅ 통과 | 각 최신 메이저 `runs.using: node24` 확인 |
| 배포 워크플로우 1회 실행 | ⬜ 머지 후 | main 푸시 시 `pages-deploy` 실행 → 경고 소거 확인 |

Closes #331