### PR TITLE
docs: 멀티클러스터 위임 서비스 글 카테고리 Kubernetes → 실무 노하우 변경

### DIFF
--- a/_posts/2026-07-02-multi-cluster-delegation-layer.md
+++ b/_posts/2026-07-02-multi-cluster-delegation-layer.md
@@ -1,8 +1,8 @@
 ---
 title: "여러 쿠버네티스 클러스터를 백엔드 하나로 다루는 법: 설정 증설 대신 위임 서비스"
 date: 2026-07-02 09:40:00 +0900
-last_modified_at: 2026-07-02 23:30:00 +0900
-categories: [기술 노하우, Kubernetes]
+last_modified_at: 2026-07-08 01:30:00 +0900
+categories: [기술 노하우, 실무 노하우]
 tags: [아키텍처, 설계, 의사결정, 헥사고날, 쿠버네티스]
 pin: true
 description: >-


### PR DESCRIPTION
## 작업 내용
멀티클러스터 위임 서비스 글의 하위 카테고리를 `Kubernetes` → `실무 노하우`로 변경한다. 이 글의 핵심은 특정 기술이 아니라 실무에서 인프라 플랫폼 변경 요구에 대처한 설계 경험이다.

## 변경 사항
- `categories: [기술 노하우, Kubernetes]` → `[기술 노하우, 실무 노하우]`
- `last_modified_at` 갱신 (2026-07-08 01:30:00 +0900)

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | front matter 메타만 변경 |
| 테스트 | ⬜ 해당없음 | - |
| 문서 동기화 | ✅ 완료 | Kubernetes 둥지 1편 잔존은 ADR-0002로 유지 |

Closes #345