### PR TITLE
chore: 블로그 소개 표면(_config description·Repo About)을 새 정체성에 정합

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,9 +6,9 @@ timezone: Asia/Seoul
 title: idean3885
 tagline: 백엔드 개발자의 일·공부 기록
 description: >-
-  Spring Boot·Kubernetes 기반 클라우드 서비스를 설계·운영하는
+  Spring Boot·Kubernetes 기반 멀티테넌시 서비스를 개발·운영하는
   7년차 백엔드 개발자.
-  GPU 기반 PaaS·시계열 파이프라인·인증서 자동화 같은 운영 사례와
+  과금 미터링 데이터 파이프라인·인증서 자동화 같은 운영 사례와
   공부 기록을 꾸준히 쌓습니다.
 
 url: "https://blog.idean.me"


### PR DESCRIPTION
Closes #356

## What

career-docs 이력서·포폴 재작성 → 청사진(idean3885 PR #49) 정합에 이어, 블로그 소개 표면 두 곳을 새 정체성에 맞춤.

- `_config.yml` description: "클라우드 서비스 설계·운영 / GPU 기반 PaaS·시계열 파이프라인" → "멀티테넌시 서비스 개발·운영 / 과금 미터링 데이터 파이프라인" (커밋 포함)
- Repo About(GitHub 설정): "AI와 함께 개발하며 배운 것들 — 방법론, 프로젝트, 기술 노하우" → "Spring Boot·Kubernetes 기반 멀티테넌시 서비스 개발·운영 사례와 공부 기록" (설정 변경, 이 PR 외 즉시 반영 완료)

홈 소개 카드(`index.md`)는 이미 새 정체성 반영됨 — 대상 아님.

## Test plan

- [x] `_config.yml` description 새 한 줄·키워드 정합 확인
- [x] 금지 표현 자가 대조 통과
- [x] Repo About 갱신 확인
- [ ] (사용자) 머지 후 blog.idean.me 메타/사이드바 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)