### PR TITLE
chore: llms.txt 전면 재작성 + README 아카이브 플러그인 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,4 @@
 
 | 플러그인 | 역할 |
 |----------|------|
-| [claude-ops-agent](https://github.com/idean3885/claude-ops-agent) | 개인 개발 운영 하네스 - 이슈·커밋·PR 플로우 자동화 |
-| [claude-content-publisher](https://github.com/idean3885/claude-content-publisher) | 콘텐츠 발행 - 원고를 블로그 포스트로 변환·발행 |
+| [claude-ops-agent](https://github.com/idean3885/claude-ops-agent) | 개인 개발 운영 하네스 - 이슈·커밋·PR 플로우 자동화 + 콘텐츠 작성·발행·검증 |

--- a/llms.txt
+++ b/llms.txt
@@ -1,50 +1,56 @@
 # blog.idean.me
 
-> 개발자의 기술적 탐구, 방법론의 진화, 운영 노하우와 의사결정의 기록을 담는 한국어 기술 블로그.
-> Jekyll + Chirpy 테마 기반. GitHub Pages로 배포.
+> Spring Boot·Kubernetes 기반 멀티테넌시 서비스를 개발·운영하는 7년차 백엔드 개발자의 한국어 기술 블로그.
+> 과금 미터링 데이터 파이프라인·인증서 자동화 같은 운영 사례와 공부 기록을 담는다.
+> Jekyll + Chirpy 테마 기반, GitHub Pages로 배포.
 
 ## 카테고리
 
 - 개발 기록: 프로젝트 경험기, 도구 적응기
 - 생각과 방법론: 사상, 철학, 설계 원칙, 의사결정
-- 기술 노하우: 운영 경험 기반 실전 지식
+- 기술 노하우: 운영·학습 기반 실전 지식
 
-## 주요 시리즈
+## 개발 기록
+
+### 미터링 시스템 구축
+- [MySQL 파티셔닝 도입기: JPA 복합 키 전환부터 시간 독립 DDL까지](https://blog.idean.me/posts/mysql-partitioning-jpa-composite-key/)
+- [어디까지 견뎌야 하는가: 미터링 용량을 세 가지 제약으로 역산한 의사결정](https://blog.idean.me/posts/metering-capacity-triple-constraint/)
+- [미터링 배치 시스템 설계: 쓰기 경합·청사진·패턴 명명·저장 전략 통일까지](https://blog.idean.me/posts/metering-batch-system-design/)
 
 ### AI 적응기
-- [AI에게 코드를 맡기고 나서 달라진 일하는 방식](https://blog.idean.me/posts/ai-changed-my-workflow/)
-- [코딩에서 사고로 — AI 시대 개발자의 역할 전환](https://blog.idean.me/posts/from-coding-to-thinking/)
-- [방법론을 들고 첫 도구를 만들었다 — Slack to Notion 제작기](https://blog.idean.me/posts/building-first-tool-with-ai/)
-- [만든 도구를 검증하다 — 테스트가 설계를 바꾼 이야기](https://blog.idean.me/posts/testing-changed-architecture/)
-- [비개발자 관점으로 써봤더니 설치부터 막혔다](https://blog.idean.me/posts/e2e-lessons-from-non-developers/)
-- [건네도 될까에서 건넸다로 — 비개발자 실전 피드백](https://blog.idean.me/posts/real-feedback-from-non-developer/)
-- [.mcpb 원클릭 설치 — Desktop Extension까지](https://blog.idean.me/posts/mcpb-one-click-install/)
-- [사내 업무 자동화 체계 구축 — devex에서 toolkit까지](https://blog.idean.me/posts/building-automation-toolkit/)
-- [두 플러그인을 하나로 — devex 사상의 실무 적용](https://blog.idean.me/posts/merging-two-plugins/)
+- [에이전트가 토큰을 호출하는 시대, 시크릿은 어떻게 둘 것인가](https://blog.idean.me/posts/permission-hierarchy-over-secret-manager/)
+- [AI에게 코드를 맡기고, 사람은 무엇을 하는가](https://blog.idean.me/posts/ai-era-developer-thinking/)
+- [여러 개발 플러그인을 하나의 에이전트로 통합하기: 1M 컨텍스트와 유지보수 비용](https://blog.idean.me/posts/dev-plugins-into-one-assistant/)
 
-### AI 교차 검증
-- [AI 협업에서의 교차 검증 — 속도가 아닌 판단을 자동화하기](https://blog.idean.me/posts/cross-verification-in-ai-collaboration/)
-- [교차 검증 도구의 구현 — 자체 검증에서 실전까지](https://blog.idean.me/posts/cross-verify-implementation/)
+### 그 외 개발 기록
+- [바이브코딩 방어로 시도한 100% 커버리지](https://blog.idean.me/posts/vibe-coding-defense-100-coverage/)
+- [비개발자에게 도구를 건넨다는 것: Slack to Notion 7개월 기록](https://blog.idean.me/posts/building-for-non-developers/)
+- [인증서 자동화: 사용자 도메인 ACME4j 구현부터 와일드카드 Jenkins 갱신까지](https://blog.idean.me/posts/cert-automation-acme-and-wildcard/)
+- [교차 검증 도구 3개월: 사상·구현·운영과 스스로 찾은 맹점](https://blog.idean.me/posts/cross-verify-tool-3month/)
 
-### 기술 노하우
-- [uvx requires-python의 함정](https://blog.idean.me/posts/uvx-python-version-trap/)
-- [Java 개발자를 위한 uvx 가이드](https://blog.idean.me/posts/uvx-guide-for-java-developers/)
-- [uvx + PyPI 배포 자동화](https://blog.idean.me/posts/uvx-pypi-deploy-automation/)
-- [Chirpy 블로그의 SEO는 이미 되어 있었다](https://blog.idean.me/posts/chirpy-seo-and-search-console/)
-- [설정 캐스케이드 — 계층형 설정 병합 패턴](https://blog.idean.me/posts/configuration-cascade/)
-- [JPA IdClass와 @Data 어노테이션 트레이드오프](https://blog.idean.me/posts/jpa-idclass-data-annotation-tradeoff/)
-- [GEO 대응 — 개발 블로그가 AI에게 읽히려면](https://blog.idean.me/posts/geo-for-dev-blog/)
-- [AI 위임의 경계 — 인프라 자동화의 빛과 그림자](https://blog.idean.me/posts/ai-delegation-boundaries/)
-- [정적 블로그에 댓글을 달았다 — Giscus와 GitHub Discussions](https://blog.idean.me/posts/giscus-comments-on-static-blog/)
-- [*.github.io에서 벗어나니 사이트맵이 바로 됐다 — 커스텀 도메인과 GA4](https://blog.idean.me/posts/custom-domain-gsc-ga4/)
+## 생각과 방법론
 
-### 생각과 방법론
-- [작은 조각들 브레인스토밍](https://blog.idean.me/posts/small-peaces-brainstorming/)
-- [하네스 엔지니어링 — LLM 에이전트의 구조적 행동 제어](https://blog.idean.me/posts/harness-engineering/)
+- [떠다니는 생각을 잡아두고 싶다 - small-peaces 브레인스토밍](https://blog.idean.me/posts/small-peaces-brainstorming/)
+- [하네스 엔지니어링 - LLM 에이전트의 구조적 행동 제어](https://blog.idean.me/posts/harness-engineering/)
 
-### 시스템 구축기
-- [시계열 수집 시스템 쓰기 경합 해결](https://blog.idean.me/posts/timeseries-write-contention/)
-- [시계열 집계 배치의 점진적 진화](https://blog.idean.me/posts/timeseries-aggregation-batch-evolution/)
-- [사용자 도메인 인증서 자동 발급 — certbot 학습에서 ACME4j 구현까지](https://blog.idean.me/posts/domain-ssl-automation-certbot-to-acme4j/)
-- [미터링 배치를 만들고 나서야 알게 된 것들 — 배치 전략과 패턴에 이름 붙이기](https://blog.idean.me/posts/batch-patterns-naming/)
-- [와일드카드 인증서 갱신 완전 자동화 — Docker IPC에서 Jenkins 배치까지](https://blog.idean.me/posts/wildcard-cert-automation-docker-ipc-jenkins/)
+## 기술 노하우
+
+### 개발 사전
+- [Configuration Cascade - 로컬이 글로벌을 이기는 설정 전략](https://blog.idean.me/posts/configuration-cascade/)
+- [Forward Auth: API Gateway의 인가 위임 방식](https://blog.idean.me/posts/forward-auth-pattern/)
+- [GitHub Release 자동화: CHANGELOG가 중심이 되는 2단계 워크플로우](https://blog.idean.me/posts/github-release-automation-changelog/)
+- [Expand-and-Contract 패턴: 무중단 DB 스키마 변경을 3단계 PR로 분할하기](https://blog.idean.me/posts/expand-and-contract-pattern/)
+- [HTTP 캐시 stale 차단: PUT 덮어쓰기와 freshness lifetime](https://blog.idean.me/posts/http-cache-stale-freshness-lifetime/)
+
+### 실무 노하우
+- [@Data vs 개별 어노테이션 - JPA 복합 키 클래스의 트레이드오프](https://blog.idean.me/posts/jpa-idclass-data-annotation-tradeoff/)
+- [AI 위임의 경계 - 인프라 자동화의 빛과 그림자](https://blog.idean.me/posts/ai-delegation-boundaries/)
+- [GitHub Pages 이중 도메인 구성기 - Cloudflare Worker로 QR코드와 커스텀 도메인 양립시키기](https://blog.idean.me/posts/github-pages-dual-domain-cloudflare-worker/)
+- [여러 쿠버네티스 클러스터를 백엔드 하나로 다루는 법: 설정 증설 대신 위임 서비스](https://blog.idean.me/posts/multi-cluster-delegation-layer/)
+
+### Kubernetes
+- [Kubernetes 마스터 노드 재기동 시 사용자 파드 네트워크가 중단되지 않는 이유](https://blog.idean.me/posts/k8s-master-reboot-data-plane-survives/)
+
+### 그 외 기술 노하우
+- [Chirpy 블로그 운영: SEO·GEO·댓글·커스텀 도메인까지](https://blog.idean.me/posts/chirpy-blog-operation/)
+- [자바 개발자가 본 uvx: 개념·PyPI 배포·GitHub Actions·requires-python 함정까지](https://blog.idean.me/posts/uvx-from-java-developer/)


### PR DESCRIPTION
Closes #360

## What

- `llms.txt` 전면 재작성: 실제 발행 24개 포스트로 재동기화. 기존 링크는 시리즈 압축 마이그레이션 전 슬러그라 대부분 깨진 상태였음. 폐지된 "시리즈" 프레임(ADR-0003) → 카테고리 기반. 옛 정체성("시계열 파이프라인")·devex/cross-verify 옛 이름 제거. 새 한 줄 정체성 반영.
- `README.md`: `claude-content-publisher`(아카이브 · ops-agent content-publish 스킬로 흡수) 행 제거, ops-agent 역할에 콘텐츠 발행 포함.

## Test plan
- [x] llms.txt 링크 24개 = 실제 발행 포스트 24개, 전 슬러그 파일 존재 검증
- [x] 금지 표현 자가 대조 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)