### PR TITLE
chore: .gitignore devex → ops-agent 경로 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ vendor/
 # macOS
 .DS_Store
 
-# devex 로컬 상태
-.devex/
+# ops-agent 로컬 상태
+.ops-agent/


### PR DESCRIPTION
ADR-0050 개명 반영. `.devex/` → `.ops-agent/` 로컬 상태 무시 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)